### PR TITLE
Modifying releasing pytorch wheels based on BOM ROCm 7.10.0 BOM

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -73,14 +73,14 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13"]
-        pytorch_version: ["release/2.7", "release/2.9"]
+        pytorch_version: ["release/2.7", "release/2.8", "release/2.9"]
         include:
           - pytorch_version: release/2.7
             pytorch_patchset: rocm_2.7
+          - pytorch_version: release/2.8
+            pytorch_patchset: rocm_2.8
           - pytorch_version: release/2.9
             pytorch_patchset: rocm_2.9
-          - pytorch_version: nightly
-            pytorch_patchset: nightly
 
     uses: ROCm/TheRock/.github/workflows/build_portable_linux_pytorch_wheels.yml@release/therock-7.10
     with:

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -71,12 +71,10 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13"]
-        pytorch_version: ["release/2.9", "nightly"]
+        pytorch_version: ["release/2.9"]
         include:
           - pytorch_version: release/2.9
             pytorch_patchset: rocm_2.9
-          - pytorch_version: nightly
-            pytorch_patchset: nightly
 
     uses: ROCm/TheRock/.github/workflows/build_windows_pytorch_wheels.yml@release/therock-7.10
     with:


### PR DESCRIPTION
This PR modifies workflow files for releasing pytorch wheels on both Windows and Linux based on ROCm 7.10.0 BOM for release 7.10

Main Release Changes made:

Pytorch Linux - 

Added Pytorch version release/2.8 

Removed - Pytorch version nightly

Pytorch Win -  

Removed - Pytorch version nightly