### PR TITLE
Adding default release branch in ref for release workflows

### DIFF
--- a/.github/workflows/release_portable_linux_packages.yml
+++ b/.github/workflows/release_portable_linux_packages.yml
@@ -37,6 +37,7 @@ on:
       ref:
         description: "Branch, tag or SHA to checkout. Otherwise, uses the default branch."
         type: string
+        default: release/therock-7.10
 #   # Trigger on a schedule to build nightly release candidates.
 #   schedule:
 #     # Runs at 04:00 AM UTC, which is 8:00 PM PST (UTC-8)

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -60,6 +60,7 @@ on:
       ref:
         description: "Branch, tag or SHA to checkout. Otherwise, uses the default branch."
         type: string
+        default: release/therock-7.10
 
 
 permissions:

--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -37,6 +37,7 @@ on:
       ref:
         description: "Branch, tag or SHA to checkout. Otherwise, uses the default branch."
         type: string
+        default: release/therock-7.10
 #   # Trigger on a schedule to build nightly release candidates.
 #   schedule:
 #     # Runs at 04:00 AM UTC, which is 8:00 PM PST (UTC-8)

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -58,6 +58,7 @@ on:
       ref:
         description: "Branch, tag or SHA to checkout. Otherwise, uses the default branch."
         type: string
+        default: release/therock-7.10
 
 
 permissions:


### PR DESCRIPTION
This PR is intended to pass a default value of branch release/therock-7.10 for the release workflows. 

This enables the checkout of the release branch in therock to build linux and pytorch wheels 

