### PR TITLE
Adding install instructions for native linux packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ https://rocm.prereleases.amd.com/packages/
 ```bash
 sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 wget https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg -O - \
-| gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+| gpg --dearmor | sudo tee /etc/apt/keyrings/amdrocm.gpg > /dev/null
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ https://rocm.prereleases.amd.com/packages/<os_profile>/ main" \
 
 ```bash
 sudo apt update
-sudo apt install rocm
+sudo apt install amdrocm-gfx94x # Change the gfx arch based on your machine.
 ```
 
 ---
@@ -145,6 +145,6 @@ EOF
 ###### Install ROCm
 
 ```bash
-sudo dnf install rocm
+sudo dnf install amdrocm-gfx94x # Change the gfx arch based on your machine.
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ enabled=1
 gpgcheck=1
 gpgkey=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
 EOF
-sudo dnf update
+sudo dnf clean all
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ https://rocm.prereleases.amd.com/packages/
 ###### Import the ROCm GPG Key
 
 ```bash
-curl -fsSL https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg \
-| sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+wget https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg -O - \
+| gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 ```
 
 ---
@@ -98,12 +99,13 @@ curl -fsSL https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg \
 ###### Add the ROCm Repository
 
 Replace `<os_profile>` with the appropriate distribution profile  
-(e.g. `debian12`, `ubuntu22.04`).
+(e.g. `debian12`, `ubuntu2404`).
 
 ```bash
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] \
-https://rocm.prereleases.amd.com/packages/<os_profile>/ main" \
-| sudo tee /etc/apt/sources.list.d/rocm.list
+sudo tee /etc/apt/sources.list.d/rocm.list << EOF
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://rocm.prereleases.amd.com/packages/<os_profile> stable main
+EOF
+sudo apt update
 ```
 
 ---
@@ -111,7 +113,6 @@ https://rocm.prereleases.amd.com/packages/<os_profile>/ main" \
 ###### Install ROCm
 
 ```bash
-sudo apt update
 sudo apt install amdrocm-gfx94x # Change the gfx arch based on your machine.
 ```
 
@@ -119,25 +120,21 @@ sudo apt install amdrocm-gfx94x # Change the gfx arch based on your machine.
 
 ##### Installing Packages on RPM-Based Systems
 
-###### Import the ROCm GPG Key
-
-```bash
-sudo rpm --import https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
-```
-
----
-
 ###### Add the ROCm Repository
 
+Replace `<os_profile>` with the appropriate distribution profile  
+(e.g. `rhel8`, `sles16`).
+
 ```bash
-sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
+sudo tee /etc/yum.repos.d/rocm.repo << EOF
 [rocm]
 name=ROCm Prerelease Repository
-baseurl=https://rocm.prereleases.amd.com/packages/rpm/
+baseurl=https://rocm.prereleases.amd.com/packages/<os_profile>/x86_64/
 enabled=1
 gpgcheck=1
 gpgkey=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
 EOF
+sudo dnf update
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -72,3 +72,79 @@ wget https://rocm.prereleases.amd.com/tarball/therock-dist-linux-gfx1151-7.9.0rc
 mkdir install
 tar -xf *.tar.gz -C install
 ```
+#### Installing from Native Linux Packages
+
+AMD provides prerelease ROCm packages for both Debian-based and RPM-based Linux distributions.
+
+Repository base URL:
+
+```
+https://rocm.prereleases.amd.com/packages/
+```
+
+---
+
+##### Installing Packages on Debian-Based Systems
+
+###### Import the ROCm GPG Key
+
+```bash
+curl -fsSL https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg \
+| sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+```
+
+---
+
+###### Add the ROCm Repository
+
+Replace `<os_profile>` with the appropriate distribution profile  
+(e.g. `debian12`, `ubuntu22.04`).
+
+```bash
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] \
+https://rocm.prereleases.amd.com/packages/<os_profile>/ main" \
+| sudo tee /etc/apt/sources.list.d/rocm.list
+```
+
+---
+
+###### Install ROCm
+
+```bash
+sudo apt update
+sudo apt install rocm
+```
+
+---
+
+##### Installing Packages on RPM-Based Systems
+
+###### Import the ROCm GPG Key
+
+```bash
+sudo rpm --import https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+```
+
+---
+
+###### Add the ROCm Repository
+
+```bash
+sudo tee /etc/yum.repos.d/rocm.repo <<'EOF'
+[rocm]
+name=ROCm Prerelease Repository
+baseurl=https://rocm.prereleases.amd.com/packages/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+EOF
+```
+
+---
+
+###### Install ROCm
+
+```bash
+sudo dnf install rocm
+```
+


### PR DESCRIPTION
## Motivation

This PR adds documentation for installing ROCm using AMD’s prerelease native Linux package repositories. The goal is to provide clear, consistent, and distribution-specific instructions for both Debian-based and RPM-based systems, making it easier for users to install ROCm without relying on containerized or source-based workflows.

## Technical Details

- Added a new **“Installing Native Linux Packages”** section to the README.
- Documented steps for installing ROCm on:
  - **Debian-based systems** using APT repositories.
  - **RPM-based systems** using DNF/YUM repositories.
- Included instructions for importing AMD’s ROCm GPG signing key.
- Used a generic `<os_profile>` placeholder to support multiple Debian/Ubuntu distributions (e.g. `debian12`, `ubuntu22.04`).
- Referenced AMD’s prerelease package repository:
  - https://rocm.prereleases.amd.com/packages/

No functional code changes are introduced; this PR is documentation-only.
