### PR TITLE
Pinning native packages build workflow to release 7.12

### DIFF
--- a/.github/workflows/build_native_linux_packages.yml
+++ b/.github/workflows/build_native_linux_packages.yml
@@ -32,7 +32,7 @@ on:
       ref:
           description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
           type: string
-          default: ''
+          default: release/therock-7.12
 
 permissions:
   id-token: write
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    uses: ROCm/TheRock/.github/workflows/build_native_linux_packages.yml@main
+    uses: ROCm/TheRock/.github/workflows/build_native_linux_packages.yml@release/therock-7.12
     with:
       artifact_group: ${{ inputs.artifact_group }}
       artifact_run_id: ${{ inputs.artifact_run_id }}


### PR DESCRIPTION
This is a follow up PR to #27 which was missed in adjustment. This PR pins both the default ref and build_native_packages workflow to 7.12 release branch.