### PR TITLE
Allow gfx90a and gfx908 as valid amdgpu_family inputs for PyTorch wheel release workflow

### DIFF
--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -11,10 +11,11 @@ on:
           - gfx110X-all
           - gfx1150
           - gfx1151
+          - gfx90a
+          - gfx908
           - gfx1152
           - gfx1153
           - gfx120X-all
-          - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
         default: gfx94X-dcgpu


### PR DESCRIPTION
This change updates the workflow_dispatch input options for amdgpu_family in release_portable_linux_pytorch_wheels.yml.

Specifically:

Adds gfx90a and gfx908 as supported input options for release 7.12.

Removes the unused gfx90X-dcgpu option.

This enables the PyTorch wheel release workflow to be triggered with gfx90a and gfx908 targets, which are used by the release pipelines but were previously not included in the allowed input values. As a result, workflow dispatch attempts with these values would fail validation.

Updating the allowed options ensures the workflow can be triggered successfully for these architectures during release builds.