### PR TITLE
Update the Pytorch release 2.10 in releases workflow

### DIFF
--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13"]
-        pytorch_git_ref: ["release/2.9"]
+        pytorch_git_ref: ["release/2.10"]
 
     uses: ROCm/TheRock/.github/workflows/build_windows_pytorch_wheels.yml@release/therock-7.12
     with:


### PR DESCRIPTION
This PR is intended to add Pytorch release/2.10 branch to the release_windows_pytorch_wheels.yml which was missed as part of 7.12 rc0.

A further PR will be raised to add back release/2.9 to the list. Intention is not re-build already build release/2.9 windows pytorch builds