### PR TITLE
Add back release 2.9 to the support list

### DIFF
--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13"]
-        pytorch_git_ref: ["release/2.10"]
+        pytorch_git_ref: ["release/2.9", "release/2.10"]
 
     uses: ROCm/TheRock/.github/workflows/build_windows_pytorch_wheels.yml@release/therock-7.12
     with:


### PR DESCRIPTION
This is a follow up PR to add back release/2.9 which was removed to accomodate the missed 2.10 windows pytorch 7.12 rc0 builds #31.

