### PR TITLE
Fix job name typo in release_windows_packages.yml

### DIFF
--- a/.github/workflows/release_windows_packages.yml
+++ b/.github/workflows/release_windows_packages.yml
@@ -52,7 +52,7 @@ permissions:
 run-name: Release Windows packages (${{ inputs.families || 'default' }}, ${{ inputs.release_type || 'nightly' }})
 
 jobs:
-  linux_packages:
+  windows_packages:
     name: Build
     uses: ROCm/TheRock/.github/workflows/release_windows_packages.yml@main
     secrets: inherit


### PR DESCRIPTION
## Technical Details

This job name is not load bearing, it gets overwritten anyways. See history at https://github.com/ROCm/rockrel/actions/workflows/release_windows_packages.yml
<img width="661" height="606" alt="image" src="https://github.com/user-attachments/assets/ff831abd-f258-45bb-ba03-46032b9af2dd" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
