### PR TITLE
Add initial multi_arch_release.yml workflow

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -63,6 +63,6 @@ jobs:
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
     permissions:
-      contents: read
+      contents: write
       actions: write
       id-token: write

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -1,0 +1,68 @@
+name: Multi-Arch Release
+
+# Expected triggers:
+#
+# Release type | Trigger details
+# ------------ | --------------------------------------------------------------
+# dev          | "workflow_dispatch" for testing with any set of inputs
+# nightly      | "schedule", or "workflow_dispatch" as needed (default inputs)
+# prerelease   | "workflow_dispatch" for stable releases (explicit GPU family lists?)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type: "dev", "nightly", or "prerelease".'
+        type: choice
+        options:
+          - dev
+          - nightly
+          - prerelease
+        default: dev
+      prerelease_version:
+        description: "(Optional) Prerelease version number, e.g. '2' for 7.10.0rc2"
+        type: string
+        default: ""
+      linux_amdgpu_families:
+        description: 'Linux GPU families. "all" = all, "none" = skip Linux.'
+        type: string
+        default: "all"
+      windows_amdgpu_families:
+        description: 'Windows GPU families. "all" = all, "none" = skip Windows.'
+        type: string
+        default: "all"
+      ref:
+        description: "TheRock branch, tag, or SHA. Empty = default branch."
+        type: string
+        default: ""
+
+  # TODO(https://github.com/ROCm/TheRock/issues/3334): Enable schedule for
+  # nightly releases once we're satisfied with dev releases and ready to advance
+
+  # schedule:
+  #   # Runs at 04:00 AM UTC, which is 8:00 PM PST (UTC-8)
+  #   - cron: '0 04 * * *'
+
+permissions:
+  contents: read
+
+run-name: >-
+  Multi-Arch Release (${{ inputs.release_type || 'nightly' }})
+  | Linux: ${{ inputs.linux_amdgpu_families || 'all' }}
+  | Windows: ${{ inputs.windows_amdgpu_families || 'all' }}
+
+jobs:
+  release:
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release.yml@main
+    secrets: inherit
+    with:
+      release_type: ${{ inputs.release_type || 'nightly' }}
+      prerelease_version: ${{ inputs.prerelease_version || '' }}
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'all' }}
+      windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || 'all' }}
+      repository: "ROCm/TheRock"
+      ref: ${{ inputs.ref || '' }}
+    permissions:
+      contents: read
+      actions: write
+      id-token: write


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/3334. This adds a new workflow wrapping https://github.com/ROCm/TheRock/blob/main/.github/workflows/multi_arch_release.yml, similar to https://github.com/ROCm/rockrel/blob/main/.github/workflows/release_portable_linux_packages.yml. We'll use this to produce multi-arch nightly and prerelease builds, while the workflows in TheRock will just be for dev releases.

## Technical Details

This depends on:
- [x] https://github.com/ROCm/TheRock/pull/4577
- [x] https://github.com/ROCm/TheRock/pull/4582
- [x] https://github.com/ROCm/TheRock/pull/4619

## Test Plan

1. Test runs in my fork where inputs were propagated sufficiently:
    * https://github.com/ScottTodd/rockrel/actions/runs/24524144810
    * https://github.com/ScottTodd/rockrel/actions/runs/24858234090
2. Run a dev release from this repository after this and the dependent PRs are merged.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
