### PR TITLE
Add release branch automation script for TheRock and ROCm submodules

### DIFF
--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
 """
 ROCm TheRock – Release Branch Automation Tool
 --------------------------------------------
@@ -8,10 +10,8 @@ caller-provided commit. The script maintains a cached clone (configurable via
 `--cache-dir`, default: `/tmp/rock-branching-cache`), fetches the latest refs,
 and hard-resets to the specified commit before creating release branches.
 
-Authentication supports both API tokens and SSH. When a token is supplied we
-call `gh auth login --with-token` so git operations transparently use the
-credential helper. Remotes are configured via `git remote set-url` (with `add`
-fallback).
+Authentication is done via SSH. Remotes are configured via
+`git remote set-url` (with `add` fallback).
 
 High-level workflow:
 1. Reuse (or populate) the cached TheRock clone; reclone only when the cache
@@ -25,7 +25,7 @@ High-level workflow:
     plus TheRock itself. Repos listed in `--exclude-list` and repos outside
     the ROCm GitHub org are filtered out.
 4. For each component:
-    a. Set up the authenticated `rocm-github` remote (token or SSH).
+    a. Set up the SSH `rocm-github` remote.
     b. Check if the release branch already exists on the remote; if so, skip
        the repo entirely (recorded as a failure).
     c. Create (or reset) the branch at the recorded commit.
@@ -36,17 +36,16 @@ Dry-run mode (the default) logs every action without touching remotes;
 `--no-dry-run` enables actual pushes.
 
 Usage:
-        python create_release_branch.py \
-                --branch_name <release-branch> \
-                --commitid <rock-commit-sha> \
-                [--apitoken <github-token>] \
+        python create_release_branch.py \\
+                --branch-name <release-branch> \\
+                --commitid <rock-commit-sha> \\
                 [--no-dry-run]
 
 Options:
-        --branch_name    Name of the release branch to create (required)
+        --branch-name    Name of the release branch to create (required)
         --commitid       Commit SHA of TheRock to branch from (required)
-        --apitoken       GitHub API token (optional; SSH is used if omitted)
-        --no-dry-run     Actually push branches to remotes (default is dry-run)
+        --dry-run/--no-dry-run
+                         Log actions without pushing to remotes (default: enabled)
         --exclude-list   Submodule repo names to skip (space-separated)
         --force-clone    Delete and reclone if cache dir is not a valid git repo
         --cache-dir      Directory to cache the TheRock clone
@@ -54,84 +53,84 @@ Options:
 """
 import argparse
 import logging
-import sys
-import subprocess
-import tempfile
-from pathlib import Path
 import shlex
 import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
 from pprint import pformat
-from typing import Dict, Any
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+@dataclass
+class RepoInfo:
+    """Information about a repository to branch."""
+
+    url: str
+    commit: str
+    path: Path
+
 
 class RockBranchingAutomation:
     """Automates creation of release branches for TheRock and its ROCm submodules."""
 
     def __init__(self, cli_args: argparse.Namespace) -> None:
-        # Collect CLI options
-        self.release_branch: str | None = cli_args.branch_name
-        self.api_token: str | None = cli_args.apitoken
-        self.dry_run = cli_args.dry_run
-        self.commitid: str | None = cli_args.commitid
+        self.release_branch: str = cli_args.branch_name
+        self.dry_run: bool = cli_args.dry_run
+        self.commitid: str = cli_args.commitid
         self.exclude_list: set[str] = set(cli_args.exclude_list or [])
         self.force_clone: bool = cli_args.force_clone
-        self.cache_dir: Path | None = Path(cli_args.cache_dir) if cli_args.cache_dir else None
+        self.cache_dir: Path | None = (
+            Path(cli_args.cache_dir) if cli_args.cache_dir else None
+        )
         self.rock_url: str = "https://github.com/ROCm/TheRock.git"
         self.cache_root: Path | None = None
 
-        # Configure structured logging
         self._logger = logging.getLogger("rock_branching")
 
-        mode = "API token mode" if self.api_token else "SSH mode"
-        self.log(f"Authentication Mode: {mode}")
+        self.log("Authentication Mode: SSH")
         self.log(f"Dry run mode = {self.dry_run}")
         if self.exclude_list:
             self.log(f"Exclude list: {self.exclude_list}")
 
     def log(self, msg: str) -> None:
-        """Common method for logging info messages."""
+        """Log an info-level message."""
         self._logger.info(msg)
 
     def run_command(
-            self, args: list[str | Path], cwd: Path, *, input: bytes | None = None, stream: bool = False
-            ) -> None:
-        """
-        Execute a subprocess command, raising CalledProcessError on failure.
+        self,
+        args: list[str | Path],
+        cwd: Path,
+        *,
+        input_data: bytes | None = None,
+        stream: bool = False,
+    ) -> None:
+        """Execute a subprocess command, raising CalledProcessError on failure.
 
         Args:
-            args:   Command and arguments to execute.
-            cwd:    Working directory for the command.
-            input:  Optional bytes piped to stdin (e.g. for ``gh auth login --with-token``).
-            stream: If True, print stdout/stderr line-by-line as it arrives
-                    (useful for long-running operations like clone/fetch).
-                    If False, buffer output and log after completion.
+            args:       Command and arguments to execute.
+            cwd:        Working directory for the command.
+            input_data: Optional bytes piped to stdin.
+            stream:     If True, print stdout/stderr line-by-line as it arrives
+                        (useful for long-running operations like clone/fetch).
+                        If False, buffer output and log after completion.
         """
-
-        def mask(text: str | bytes) -> str:
-            if isinstance(text, bytes):
-                text = text.decode(errors="ignore")
-            if not text or not self.api_token:
-                return text or ""
-            return text.replace(self.api_token, "***")
-
         cmd = args if isinstance(args, list) else [args]
-        masked_cmd = mask(shlex.join(map(str, cmd)))
-        self.log(f"++ Exec [{cwd}]$ {masked_cmd}")
+        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
         sys.stdout.flush()
 
         if stream:
-            # STREAM OUTPUT LIVE
             process = subprocess.Popen(
                 cmd,
                 cwd=str(cwd),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                text=True
+                text=True,
             )
 
             for line in process.stdout:
-                self.log(mask(line.rstrip()))
+                self.log(line.rstrip())
 
             ret = process.wait()
             if ret != 0:
@@ -139,41 +138,52 @@ class RockBranchingAutomation:
 
             return
 
-        # NORMAL (buffered) MODE
         try:
             result = subprocess.run(
                 cmd,
                 cwd=str(cwd),
                 shell=False,
-                input=input,
+                input=input_data,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=True,
-                stdin=None if input else subprocess.DEVNULL,
+                stdin=None if input_data else subprocess.DEVNULL,
                 text=False,
             )
 
             if result.stdout:
-                self.log(mask(result.stdout))
+                self.log(
+                    result.stdout
+                    if isinstance(result.stdout, str)
+                    else result.stdout.decode(errors="ignore")
+                )
             if result.stderr:
-                self.log(mask(result.stderr))
+                self.log(
+                    result.stderr
+                    if isinstance(result.stderr, str)
+                    else result.stderr.decode(errors="ignore")
+                )
 
         except subprocess.CalledProcessError as exc:
-            self.log(mask(exc.stdout or b""))
-            self.log(mask(exc.stderr or b""))
+            self.log(
+                (exc.stdout or b"").decode(errors="ignore")
+                if isinstance(exc.stdout, bytes)
+                else (exc.stdout or "")
+            )
+            self.log(
+                (exc.stderr or b"").decode(errors="ignore")
+                if isinstance(exc.stderr, bytes)
+                else (exc.stderr or "")
+            )
             raise
 
-    def run_command_output(
-            self, args: list[str | Path], cwd: Path) -> str:
-        """
-        Run a command and return its stripped stdout as a string.
+    def run_command_output(self, args: list[str | Path], cwd: Path) -> str:
+        """Run a command and return its stripped stdout as a string.
+
         Raises CalledProcessError on non-zero exit.
         """
         cmd = args if isinstance(args, list) else [args]
-        masked_cmd = shlex.join(map(str, cmd))
-        if self.api_token:
-            masked_cmd = masked_cmd.replace(self.api_token, "***")
-        self.log(f"++ Exec [{cwd}]$ {masked_cmd}")
+        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
 
         result = subprocess.run(
             cmd,
@@ -186,27 +196,9 @@ class RockBranchingAutomation:
         )
         return result.stdout.strip()
 
-    def _authenticate_gh(self) -> None:
-        """Authenticate with GitHub CLI if an API token is available."""
-        auth_dir = self.cache_root or Path(tempfile.gettempdir())
-        auth_dir.mkdir(parents=True, exist_ok=True)
-        if self.api_token:
-            try:
-                self.run_command(["gh", "--version"], cwd=auth_dir)
-                self.run_command(
-                    ["gh", "auth", "login", "--hostname", "github.com", "--with-token"],
-                    cwd=auth_dir,
-                    input=self.api_token.encode(),
-                )
-            except subprocess.CalledProcessError as exc:
-                self.log(f"GitHub CLI authentication failed: {exc}")
-                self.log("Continuing with git operations (may fail if not authenticated via SSH)...")
-        else:
-            self.log("Skipping gh auth login (SSH mode). Assuming user already authenticated.")
-
     def _setup_remote(self, url: str, repo_dir: Path) -> None:
         """Add or update the rocm-github remote for a repo."""
-        remote_url = self.tokenize_url(url)
+        remote_url = self.convert_to_ssh(url)
         try:
             self.run_command(
                 ["git", "remote", "set-url", "rocm-github", remote_url],
@@ -239,97 +231,92 @@ class RockBranchingAutomation:
     def _push_branch(self, repo_name: str, repo_dir: Path) -> None:
         """Push the release branch to rocm-github, respecting dry-run mode."""
         if self.dry_run:
-            self.log(f"[DRY RUN] Skipping push of {self.release_branch} for {repo_name}")
+            self.log(
+                f"[DRY RUN] Skipping push of {self.release_branch} "
+                f"for {repo_name}"
+            )
         else:
             self.run_command(
                 ["git", "push", "rocm-github", self.release_branch],
                 cwd=repo_dir,
             )
 
-    def execute_plan(
-            self, plan: Dict[str, Dict[str, str]]) -> None:
-        """
-        Execute the branching plan for every repo in *plan*:
-        1. Set up the ``rocm-github`` remote with the authenticated URL.
+    def execute_plan(self, plan: dict[str, RepoInfo]) -> None:
+        """Execute the branching plan for every repo in *plan*.
+
+        For each repo:
+        1. Set up the ``rocm-github`` remote with the SSH URL.
         2. Guard against a pre-existing remote branch (skip if found).
         3. Create (or reset) the release branch at the recorded commit SHA.
         4. Push to ``rocm-github`` (skipped in dry-run mode).
         """
-        successful_repos: Dict[str, Dict[str, str]] = {}
-        failed_repos: Dict[str, Dict[str, Any]] = {}
+        successful_repos: dict[str, RepoInfo] = {}
+        failed_repos: dict[str, str] = {}
 
-        self._authenticate_gh()
+        for repo_name, info in plan.items():
+            self.log(f"Processing {repo_name} at {info.path}")
 
-        for repo_name, meta in plan.items():
-            url = meta.get("url")
-            commit = meta.get("commit")
-            repo_dir = Path(meta.get("path"))
-
-            self.log(f"Processing {repo_name} at {repo_dir}")
-
-            if not repo_dir.exists():
-                failed_repos[repo_name] = {"error": f"Repo path does not exist: {repo_dir}"}
+            if not info.path.exists():
+                failed_repos[repo_name] = (
+                    f"Repo path does not exist: {info.path}"
+                )
                 continue
 
             try:
-                self._setup_remote(url, repo_dir)
+                self._setup_remote(info.url, info.path)
             except subprocess.CalledProcessError as exc:
-                failed_repos[repo_name] = {"error": f"Remote setup failed: {exc}"}
+                failed_repos[repo_name] = f"Remote setup failed: {exc}"
                 continue
 
             try:
-                branch_exists = self._remote_branch_exists(repo_dir)
+                branch_exists = self._remote_branch_exists(info.path)
             except subprocess.CalledProcessError as exc:
-                failed_repos[repo_name] = {"error": f"Remote branch check failed: {exc}"}
+                failed_repos[repo_name] = (
+                    f"Remote branch check failed: {exc}"
+                )
                 continue
 
             if branch_exists:
-                msg = f"Remote branch {self.release_branch} already exists on rocm-github"
+                msg = (
+                    f"Remote branch {self.release_branch} already exists "
+                    "on rocm-github"
+                )
                 self.log(msg)
-                failed_repos[repo_name] = {"error": msg}
+                failed_repos[repo_name] = msg
                 continue
 
             try:
-                self._create_branch(commit, repo_dir)
+                self._create_branch(info.commit, info.path)
             except subprocess.CalledProcessError as exc:
-                failed_repos[repo_name] = {
-                    "error": f"Branch creation failed at {commit}: {exc}"
-                }
+                failed_repos[repo_name] = (
+                    f"Branch creation failed at {info.commit}: {exc}"
+                )
                 continue
 
             try:
-                self._push_branch(repo_name, repo_dir)
-                successful_repos[repo_name] = {
-                    "url": url,
-                    "commit": commit,
-                    "branch": self.release_branch,
-                }
+                self._push_branch(repo_name, info.path)
+                successful_repos[repo_name] = info
             except subprocess.CalledProcessError as exc:
-                failed_repos[repo_name] = {"error": f"Branch push failed: {exc}"}
+                failed_repos[repo_name] = f"Branch push failed: {exc}"
 
-        self.log(f"Summary: {len(successful_repos)} succeeded, {len(failed_repos)} failed out of {len(plan)} repos")
+        self.log(
+            f"Summary: {len(successful_repos)} succeeded, "
+            f"{len(failed_repos)} failed out of {len(plan)} repos"
+        )
         if successful_repos:
             self.log(f"Successful repos: {pformat(successful_repos)}")
         if failed_repos:
             self.log(f"Failed repos: {pformat(failed_repos)}")
 
     def convert_to_ssh(self, url: str) -> str:
-        """Convert https://github.com/X/Y.git → git@github.com:X/Y.git"""
+        """Convert https://github.com/X/Y.git to git@github.com:X/Y.git."""
         if url.startswith("https://github.com/"):
             path = url.replace("https://github.com/", "")
             return f"git@github.com:{path}"
         return url
 
-    def tokenize_url(self, url: str) -> str:
-        """Return HTTPS+token URL if token provided, else SSH URL."""
-        if self.api_token:
-            return url.replace("https://", f"https://{self.api_token}@")
-        else:
-            # SSH mode → convert URL to SSH
-            return self.convert_to_ssh(url)
-
-    def get_submodule_url_map(self, repo_dir: Path) -> Dict[str, str]:
-        """Return mapping of submodule working-tree paths → remote URLs from .gitmodules."""
+    def get_submodule_url_map(self, repo_dir: Path) -> dict[str, str]:
+        """Return mapping of submodule working-tree paths to remote URLs."""
         gitmodules_path = repo_dir / ".gitmodules"
         if not gitmodules_path.exists():
             return {}
@@ -337,21 +324,22 @@ class RockBranchingAutomation:
         try:
             path_entries = self.run_command_output(
                 [
-                    "git", "config", "--file", str(gitmodules_path),
-                    "--get-regexp", r"submodule\..*\.path",
+                    "git",
+                    "config",
+                    "--file",
+                    str(gitmodules_path),
+                    "--get-regexp",
+                    r"submodule\..*\.path",
                 ],
                 cwd=repo_dir,
             )
         except subprocess.CalledProcessError:
             return {}
 
-        url_map: Dict[str, str] = {}
+        url_map: dict[str, str] = {}
         for line in path_entries.splitlines():
-            # Each line is from `git config --get-regexp` and looks like:
+            # Each line looks like:
             #   "submodule.external/hipcc.path external/hipcc"
-            # We split into key="submodule.external/hipcc.path" and
-            # path_value="external/hipcc", then strip the trailing ".path"
-            # to get section="submodule.external/hipcc" for the URL lookup.
             parts = line.strip().split(None, 1)
             if len(parts) != 2:
                 continue
@@ -360,8 +348,12 @@ class RockBranchingAutomation:
             try:
                 url = self.run_command_output(
                     [
-                        "git", "config", "--file", str(gitmodules_path),
-                        "--get", f"{section}.url",
+                        "git",
+                        "config",
+                        "--file",
+                        str(gitmodules_path),
+                        "--get",
+                        f"{section}.url",
                     ],
                     cwd=repo_dir,
                 )
@@ -372,9 +364,8 @@ class RockBranchingAutomation:
 
         return url_map
 
-    def build_plan(self) -> Dict[str, Dict[str, str]]:
-        """
-        Build the branching execution plan.
+    def build_plan(self) -> dict[str, RepoInfo]:
+        """Build the branching execution plan.
 
         1. Clone (or reuse cached clone of) TheRock.
         2. Check out and hard-reset to ``self.commitid``.
@@ -383,35 +374,40 @@ class RockBranchingAutomation:
            submodule's commit SHA, remote URL, and local path.
         5. Return a dict keyed by repo name, including TheRock itself.
         """
-        cache_root = self.cache_dir or Path(tempfile.gettempdir()) / "rock-branching-cache"
+        cache_root = (
+            self.cache_dir
+            or Path(tempfile.gettempdir()) / "rock-branching-cache"
+        )
         cache_root.mkdir(parents=True, exist_ok=True)
         clone_dir = cache_root / "TheRock"
         self.cache_root = cache_root
 
-        # Ensure cache directory contains a valid git repo; otherwise reclone
         needs_clone = not clone_dir.exists()
         if not needs_clone and not (clone_dir / ".git").exists():
             if not self.force_clone:
                 raise RuntimeError(
-                    f"Cache directory {clone_dir} exists but is not a git repo. "
-                    "Use --force-clone to delete it and reclone."
+                    f"Cache directory {clone_dir} exists but is not a git "
+                    "repo. Use --force-clone to delete it and reclone."
                 )
-            self.log(f"Cache directory {clone_dir} is not a git repo; removing before reclone (--force-clone)")
+            self.log(
+                f"Cache directory {clone_dir} is not a git repo; "
+                "removing before reclone (--force-clone)"
+            )
             shutil.rmtree(clone_dir)
             needs_clone = True
 
         if needs_clone:
-            self.log(f"Cloning TheRock repo from {self.rock_url} into {clone_dir}")
+            self.log(
+                f"Cloning TheRock repo from {self.rock_url} into {clone_dir}"
+            )
             self.run_command(
                 ["git", "clone", str(self.rock_url), str(clone_dir)],
                 cwd=cache_root,
                 stream=True,
             )
         else:
-            # Repo exists – ensure it's a valid git repo and has the right remote
             self.log(f"Reusing existing TheRock repo at {clone_dir}")
 
-            # Optional: verify remote URL matches expected
             try:
                 remote_url = self.run_command_output(
                     ["git", "remote", "get-url", "origin"],
@@ -419,40 +415,63 @@ class RockBranchingAutomation:
                 )
                 if "TheRock" not in remote_url:
                     raise RuntimeError(
-                        f"Existing repo at {clone_dir} does not look like TheRock (origin={remote_url})"
+                        f"Existing repo at {clone_dir} does not look like "
+                        f"TheRock (origin={remote_url})"
                     )
             except subprocess.CalledProcessError as exc:
-                raise RuntimeError(f"Failed to inspect existing repo at {clone_dir}: {exc}") from exc
+                raise RuntimeError(
+                    f"Failed to inspect existing repo at {clone_dir}: {exc}"
+                ) from exc
 
-            # Update refs from origin
             self.log("Fetching latest changes for existing TheRock clone...")
-            self.run_command(["git", "fetch", "origin", "--prune", "--recurse-submodules=on-demand"],
-                             cwd=clone_dir, stream=True)
+            self.run_command(
+                [
+                    "git",
+                    "fetch",
+                    "origin",
+                    "--prune",
+                    "--recurse-submodules=on-demand",
+                ],
+                cwd=clone_dir,
+                stream=True,
+            )
 
         fetch_script = clone_dir / "build_tools" / "fetch_sources.py"
         rock_commit = self.commitid
 
-        # Hard-reset the working tree to the exact requested commit.
         self.log(f"Checking out TheRock at commit {rock_commit}")
         self.run_command(["git", "checkout", rock_commit], cwd=clone_dir)
-        self.run_command(["git", "reset", "--hard", rock_commit], cwd=clone_dir)
+        self.run_command(
+            ["git", "reset", "--hard", rock_commit], cwd=clone_dir
+        )
 
         if fetch_script.exists():
-            self.log("Updating submodules via fetch_sources.py (jobs=10, no patches)...")
+            self.log(
+                "Updating submodules via fetch_sources.py "
+                "(jobs=10, no patches)..."
+            )
             self.run_command(
-                ["python3", str(fetch_script), "--jobs", "10", "--no-apply-patches"],
+                [
+                    "python3",
+                    str(fetch_script),
+                    "--jobs",
+                    "10",
+                    "--no-apply-patches",
+                ],
                 cwd=clone_dir,
                 stream=True,
             )
         else:
-            self.log("fetch_sources.py not found; falling back to git submodule update")
+            self.log(
+                "fetch_sources.py not found; "
+                "falling back to git submodule update"
+            )
             self.run_command(
                 ["git", "submodule", "update", "--init", "--recursive"],
                 cwd=clone_dir,
                 stream=True,
             )
 
-        # Read submodule SHAs at this commit
         self.log("Reading submodule status...")
         try:
             status_output = self.run_command_output(
@@ -461,16 +480,16 @@ class RockBranchingAutomation:
             )
             lines = status_output.split("\n") if status_output else []
         except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"Failed to read submodule status: {exc}") from exc
+            raise RuntimeError(
+                f"Failed to read submodule status: {exc}"
+            ) from exc
 
-        # Parse .gitmodules to map paths → URLs
         url_map = self.get_submodule_url_map(clone_dir)
 
-        plan: Dict[str, Dict[str, str]] = {}
+        plan: dict[str, RepoInfo] = {}
 
         # Each line from `git submodule status` looks like:
         #   " <sha> <path> (<describe>)"  or  "-<sha> <path>" (not initialized)
-        # The leading character is ' ' (in-sync), '+' (changed), or '-' (not init).
         for line in lines:
             if not line:
                 continue
@@ -485,70 +504,98 @@ class RockBranchingAutomation:
             repo_url = url_map.get(path)
 
             if not repo_url:
-                self.log(f"No URL found for submodule {path} in .gitmodules")
+                self.log(
+                    f"No URL found for submodule {path} in .gitmodules"
+                )
                 continue
 
-            # Skip repos in the exclude list
             if repo_name in self.exclude_list:
                 self.log(f"Skipping {repo_name} (in exclude list)")
                 continue
 
-            # Skip repos not under the ROCm organization
             url_lower = repo_url.lower()
-            if "github.com/rocm/" not in url_lower and "github.com:rocm/" not in url_lower:
-                self.log(f"Skipping {repo_name} (not a ROCm org repo: {repo_url})")
+            if (
+                "github.com/rocm/" not in url_lower
+                and "github.com:rocm/" not in url_lower
+            ):
+                self.log(
+                    f"Skipping {repo_name} "
+                    f"(not a ROCm org repo: {repo_url})"
+                )
                 continue
 
-            plan[repo_name] = {
-                "url": repo_url,
-                "commit": sha,
-                "path": str(clone_dir / path),
-            }
+            plan[repo_name] = RepoInfo(
+                url=repo_url,
+                commit=sha,
+                path=clone_dir / path,
+            )
 
-        # Add TheRock itself to the plan
-        plan["TheRock"] = {
-            "url": self.rock_url,
-            "commit": rock_commit,
-            "path": str(clone_dir),
-        }
+        plan["TheRock"] = RepoInfo(
+            url=self.rock_url,
+            commit=rock_commit,
+            path=clone_dir,
+        )
 
         return plan
 
-    def main(self) -> None:
+    def run(self) -> None:
+        """Build the execution plan and execute it."""
         plan = self.build_plan()
         self.log(f"Execution plan:\n{pformat(plan)}")
         self.execute_plan(plan)
 
-def parse_args():
+
+def main(argv: list[str]) -> int:
+    """Parse arguments and run the branching automation."""
     parser = argparse.ArgumentParser(
-        description="Rock Branching Automation Tool"
-        )
-    parser.add_argument("-B", "--branch_name", required=True)
+        description="Rock Branching Automation Tool",
+    )
     parser.add_argument(
-        "-C", "--commitid", required=True, help="Commit ID of TheRock"
-        )
+        "-B",
+        "--branch-name",
+        required=True,
+        help="Name of the release branch to create",
+    )
     parser.add_argument(
-        "-A", "--apitoken", required=False, help="GitHub API token (optional)"
-        )
+        "-C",
+        "--commitid",
+        required=True,
+        help="Commit ID of TheRock to branch from",
+    )
     parser.add_argument(
-        "--no-dry-run", action="store_false", dest="dry_run"
-        )
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Log actions without pushing to remotes (default: enabled)",
+    )
     parser.add_argument(
-        "--exclude-list", nargs="*", default=[],
-        help="List of submodule repo names to exclude from branching"
-        )
+        "--exclude-list",
+        nargs="*",
+        default=[],
+        help="List of submodule repo names to exclude from branching",
+    )
     parser.add_argument(
-        "--force-clone", action="store_true", default=False,
-        help="Delete and reclone if cache directory exists but is not a valid git repo"
-        )
+        "--force-clone",
+        action="store_true",
+        default=False,
+        help="Delete and reclone if cache directory exists but is not a "
+        "valid git repo",
+    )
     parser.add_argument(
-        "--cache-dir", default=None,
-        help="Directory to cache the TheRock clone (default: /tmp/rock-branching-cache)"
-        )
-    parser.set_defaults(dry_run=True)
-    return parser.parse_args()
+        "--cache-dir",
+        default=None,
+        help="Directory to cache the TheRock clone "
+        "(default: /tmp/rock-branching-cache)",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+
+    RockBranchingAutomation(args).run()
+    return 0
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    RockBranchingAutomation(args).main()
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -53,6 +53,7 @@ Options:
 """
 import argparse
 import logging
+import re
 import shlex
 import shutil
 import subprocess
@@ -79,6 +80,13 @@ class RockBranchingAutomation:
         self.release_branch: str = cli_args.branch_name
         self.dry_run: bool = cli_args.dry_run
         self.commitid: str = cli_args.commitid
+
+        if not re.fullmatch(r"[0-9a-f]{40}", self.commitid):
+            raise SystemExit(
+                f"ERROR: --commitid must be a full 40-character lowercase hex "
+                f"SHA-1 hash, got: {self.commitid!r}"
+            )
+
         self.exclude_list: set[str] = set(cli_args.exclude_list or [])
         self.force_clone: bool = cli_args.force_clone
         self.cache_dir: Path | None = (
@@ -105,6 +113,7 @@ class RockBranchingAutomation:
         *,
         input_data: bytes | None = None,
         stream: bool = False,
+        timeout: int | None = None,
     ) -> None:
         """Execute a subprocess command, raising CalledProcessError on failure.
 
@@ -115,6 +124,7 @@ class RockBranchingAutomation:
             stream:     If True, print stdout/stderr line-by-line as it arrives
                         (useful for long-running operations like clone/fetch).
                         If False, buffer output and log after completion.
+            timeout:    Maximum seconds to wait before raising TimeoutExpired.
         """
         cmd = args if isinstance(args, list) else [args]
         self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
@@ -149,6 +159,7 @@ class RockBranchingAutomation:
                 check=True,
                 stdin=None if input_data else subprocess.DEVNULL,
                 text=False,
+                timeout=timeout,
             )
 
             if result.stdout:
@@ -177,10 +188,13 @@ class RockBranchingAutomation:
             )
             raise
 
-    def run_command_output(self, args: list[str | Path], cwd: Path) -> str:
+    def run_command_output(
+        self, args: list[str | Path], cwd: Path, timeout: int | None = None
+    ) -> str:
         """Run a command and return its stripped stdout as a string.
 
         Raises CalledProcessError on non-zero exit.
+        Raises subprocess.TimeoutExpired when *timeout* seconds elapse.
         """
         cmd = args if isinstance(args, list) else [args]
         self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
@@ -193,6 +207,7 @@ class RockBranchingAutomation:
             text=True,
             check=True,
             stdin=subprocess.DEVNULL,
+            timeout=timeout,
         )
         return result.stdout.strip()
 
@@ -214,10 +229,12 @@ class RockBranchingAutomation:
         """Return True if the release branch already exists on rocm-github.
 
         Raises CalledProcessError if the remote check itself fails.
+        Raises subprocess.TimeoutExpired if the network call hangs (60 s).
         """
         output = self.run_command_output(
             ["git", "ls-remote", "--heads", "rocm-github", self.release_branch],
             cwd=repo_dir,
+            timeout=60,
         )
         return bool(output)
 
@@ -239,6 +256,7 @@ class RockBranchingAutomation:
             self.run_command(
                 ["git", "push", "rocm-github", self.release_branch],
                 cwd=repo_dir,
+                timeout=120,
             )
 
     def execute_plan(self, plan: dict[str, RepoInfo]) -> None:
@@ -251,6 +269,7 @@ class RockBranchingAutomation:
         4. Push to ``rocm-github`` (skipped in dry-run mode).
         """
         successful_repos: dict[str, RepoInfo] = {}
+        skipped_repos: dict[str, str] = {}
         failed_repos: dict[str, str] = {}
 
         for repo_name, info in plan.items():
@@ -282,7 +301,7 @@ class RockBranchingAutomation:
                     "on rocm-github"
                 )
                 self.log(msg)
-                failed_repos[repo_name] = msg
+                skipped_repos[repo_name] = msg
                 continue
 
             try:
@@ -301,10 +320,13 @@ class RockBranchingAutomation:
 
         self.log(
             f"Summary: {len(successful_repos)} succeeded, "
+            f"{len(skipped_repos)} skipped, "
             f"{len(failed_repos)} failed out of {len(plan)} repos"
         )
         if successful_repos:
             self.log(f"Successful repos: {pformat(successful_repos)}")
+        if skipped_repos:
+            self.log(f"Skipped repos (branch already exists): {pformat(skipped_repos)}")
         if failed_repos:
             self.log(f"Failed repos: {pformat(failed_repos)}")
 

--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""
+ROCm TheRock – Release Branch Automation Tool
+--------------------------------------------
+
+Creates release branches for TheRock and every tracked ROCm submodule at a
+caller-provided commit. The script maintains a cached clone (configurable via
+`--cache-dir`, default: `/tmp/rock-branching-cache`), fetches the latest refs,
+and hard-resets to the specified commit before creating release branches.
+
+Authentication supports both API tokens and SSH. When a token is supplied we
+call `gh auth login --with-token` so git operations transparently use the
+credential helper. Remotes are configured via `git remote set-url` (with `add`
+fallback).
+
+High-level workflow:
+1. Reuse (or populate) the cached TheRock clone; reclone only when the cache
+    is missing or corrupt (`--force-clone` deletes and reclones when the cache
+    directory exists but is not a valid git repo). Otherwise fetch/prune to
+    pick up new commits.
+2. Hard-reset to the requested commit and populate submodules via
+    `fetch_sources.py` when available (fallback to `git submodule update`).
+3. Build an execution plan from `.gitmodules` + `git submodule status`,
+    capturing repo URL, commit SHA, and working tree path for each component
+    plus TheRock itself. Repos listed in `--exclude-list` and repos outside
+    the ROCm GitHub org are filtered out.
+4. For each component:
+    a. Set up the authenticated `rocm-github` remote (token or SSH).
+    b. Check if the release branch already exists on the remote; if so, skip
+       the repo entirely (recorded as a failure).
+    c. Create (or reset) the branch at the recorded commit.
+    d. Push to `rocm-github` (skipped in dry-run mode).
+5. Log a summary of successful and failed repos.
+
+Dry-run mode (the default) logs every action without touching remotes;
+`--no-dry-run` enables actual pushes.
+
+Usage:
+        python create_release_branch.py \
+                --branch_name <release-branch> \
+                --commitid <rock-commit-sha> \
+                [--apitoken <github-token>] \
+                [--no-dry-run]
+
+Options:
+        --branch_name    Name of the release branch to create (required)
+        --commitid       Commit SHA of TheRock to branch from (required)
+        --apitoken       GitHub API token (optional; SSH is used if omitted)
+        --no-dry-run     Actually push branches to remotes (default is dry-run)
+        --exclude-list   Submodule repo names to skip (space-separated)
+        --force-clone    Delete and reclone if cache dir is not a valid git repo
+        --cache-dir      Directory to cache the TheRock clone
+                         (default: /tmp/rock-branching-cache)
+"""
+import argparse
+import logging
+import sys
+import subprocess
+import tempfile
+from pathlib import Path
+import shlex
+import shutil
+from pprint import pformat
+from typing import Dict, Any
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+class RockBranchingAutomation:
+    """Automates creation of release branches for TheRock and its ROCm submodules."""
+
+    def __init__(self, cli_args: argparse.Namespace) -> None:
+        # Collect CLI options
+        self.release_branch: str | None = cli_args.branch_name
+        self.api_token: str | None = cli_args.apitoken
+        self.dry_run = cli_args.dry_run
+        self.commitid: str | None = cli_args.commitid
+        self.exclude_list: set[str] = set(cli_args.exclude_list or [])
+        self.force_clone: bool = cli_args.force_clone
+        self.cache_dir: Path | None = Path(cli_args.cache_dir) if cli_args.cache_dir else None
+        self.rock_url: str = "https://github.com/ROCm/TheRock.git"
+        self.cache_root: Path | None = None
+
+        # Configure structured logging
+        self._logger = logging.getLogger("rock_branching")
+
+        mode = "API token mode" if self.api_token else "SSH mode"
+        self.log(f"Authentication Mode: {mode}")
+        self.log(f"Dry run mode = {self.dry_run}")
+        if self.exclude_list:
+            self.log(f"Exclude list: {self.exclude_list}")
+
+    def log(self, msg: str) -> None:
+        """Common method for logging info messages."""
+        self._logger.info(msg)
+
+    def run_command(
+            self, args: list[str | Path], cwd: Path, *, input: bytes | None = None, stream: bool = False
+            ) -> None:
+        """
+        Execute a subprocess command, raising CalledProcessError on failure.
+
+        Args:
+            args:   Command and arguments to execute.
+            cwd:    Working directory for the command.
+            input:  Optional bytes piped to stdin (e.g. for ``gh auth login --with-token``).
+            stream: If True, print stdout/stderr line-by-line as it arrives
+                    (useful for long-running operations like clone/fetch).
+                    If False, buffer output and log after completion.
+        """
+
+        def mask(text: str | bytes) -> str:
+            if isinstance(text, bytes):
+                text = text.decode(errors="ignore")
+            if not text or not self.api_token:
+                return text or ""
+            return text.replace(self.api_token, "***")
+
+        cmd = args if isinstance(args, list) else [args]
+        masked_cmd = mask(shlex.join(map(str, cmd)))
+        self.log(f"++ Exec [{cwd}]$ {masked_cmd}")
+        sys.stdout.flush()
+
+        if stream:
+            # STREAM OUTPUT LIVE
+            process = subprocess.Popen(
+                cmd,
+                cwd=str(cwd),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True
+            )
+
+            for line in process.stdout:
+                self.log(mask(line.rstrip()))
+
+            ret = process.wait()
+            if ret != 0:
+                raise subprocess.CalledProcessError(ret, cmd)
+
+            return
+
+        # NORMAL (buffered) MODE
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=str(cwd),
+                shell=False,
+                input=input,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+                stdin=None if input else subprocess.DEVNULL,
+                text=False,
+            )
+
+            if result.stdout:
+                self.log(mask(result.stdout))
+            if result.stderr:
+                self.log(mask(result.stderr))
+
+        except subprocess.CalledProcessError as exc:
+            self.log(mask(exc.stdout or b""))
+            self.log(mask(exc.stderr or b""))
+            raise
+
+    def run_command_output(
+            self, args: list[str | Path], cwd: Path) -> str:
+        """
+        Run a command and return its stripped stdout as a string.
+        Raises CalledProcessError on non-zero exit.
+        """
+        cmd = args if isinstance(args, list) else [args]
+        masked_cmd = shlex.join(map(str, cmd))
+        if self.api_token:
+            masked_cmd = masked_cmd.replace(self.api_token, "***")
+        self.log(f"++ Exec [{cwd}]$ {masked_cmd}")
+
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+            stdin=subprocess.DEVNULL,
+        )
+        return result.stdout.strip()
+
+    def _authenticate_gh(self) -> None:
+        """Authenticate with GitHub CLI if an API token is available."""
+        auth_dir = self.cache_root or Path(tempfile.gettempdir())
+        auth_dir.mkdir(parents=True, exist_ok=True)
+        if self.api_token:
+            try:
+                self.run_command(["gh", "--version"], cwd=auth_dir)
+                self.run_command(
+                    ["gh", "auth", "login", "--hostname", "github.com", "--with-token"],
+                    cwd=auth_dir,
+                    input=self.api_token.encode(),
+                )
+            except subprocess.CalledProcessError as exc:
+                self.log(f"GitHub CLI authentication failed: {exc}")
+                self.log("Continuing with git operations (may fail if not authenticated via SSH)...")
+        else:
+            self.log("Skipping gh auth login (SSH mode). Assuming user already authenticated.")
+
+    def _setup_remote(self, url: str, repo_dir: Path) -> None:
+        """Add or update the rocm-github remote for a repo."""
+        remote_url = self.tokenize_url(url)
+        try:
+            self.run_command(
+                ["git", "remote", "set-url", "rocm-github", remote_url],
+                cwd=repo_dir,
+            )
+        except subprocess.CalledProcessError:
+            self.run_command(
+                ["git", "remote", "add", "rocm-github", remote_url],
+                cwd=repo_dir,
+            )
+
+    def _remote_branch_exists(self, repo_dir: Path) -> bool:
+        """Return True if the release branch already exists on rocm-github.
+
+        Raises CalledProcessError if the remote check itself fails.
+        """
+        output = self.run_command_output(
+            ["git", "ls-remote", "--heads", "rocm-github", self.release_branch],
+            cwd=repo_dir,
+        )
+        return bool(output)
+
+    def _create_branch(self, commit: str, repo_dir: Path) -> None:
+        """Create (or reset) the release branch at the given commit."""
+        self.run_command(
+            ["git", "checkout", "-B", self.release_branch, commit],
+            cwd=repo_dir,
+        )
+
+    def _push_branch(self, repo_name: str, repo_dir: Path) -> None:
+        """Push the release branch to rocm-github, respecting dry-run mode."""
+        if self.dry_run:
+            self.log(f"[DRY RUN] Skipping push of {self.release_branch} for {repo_name}")
+        else:
+            self.run_command(
+                ["git", "push", "rocm-github", self.release_branch],
+                cwd=repo_dir,
+            )
+
+    def execute_plan(
+            self, plan: Dict[str, Dict[str, str]]) -> None:
+        """
+        Execute the branching plan for every repo in *plan*:
+        1. Set up the ``rocm-github`` remote with the authenticated URL.
+        2. Guard against a pre-existing remote branch (skip if found).
+        3. Create (or reset) the release branch at the recorded commit SHA.
+        4. Push to ``rocm-github`` (skipped in dry-run mode).
+        """
+        successful_repos: Dict[str, Dict[str, str]] = {}
+        failed_repos: Dict[str, Dict[str, Any]] = {}
+
+        self._authenticate_gh()
+
+        for repo_name, meta in plan.items():
+            url = meta.get("url")
+            commit = meta.get("commit")
+            repo_dir = Path(meta.get("path"))
+
+            self.log(f"Processing {repo_name} at {repo_dir}")
+
+            if not repo_dir.exists():
+                failed_repos[repo_name] = {"error": f"Repo path does not exist: {repo_dir}"}
+                continue
+
+            try:
+                self._setup_remote(url, repo_dir)
+            except subprocess.CalledProcessError as exc:
+                failed_repos[repo_name] = {"error": f"Remote setup failed: {exc}"}
+                continue
+
+            try:
+                branch_exists = self._remote_branch_exists(repo_dir)
+            except subprocess.CalledProcessError as exc:
+                failed_repos[repo_name] = {"error": f"Remote branch check failed: {exc}"}
+                continue
+
+            if branch_exists:
+                msg = f"Remote branch {self.release_branch} already exists on rocm-github"
+                self.log(msg)
+                failed_repos[repo_name] = {"error": msg}
+                continue
+
+            try:
+                self._create_branch(commit, repo_dir)
+            except subprocess.CalledProcessError as exc:
+                failed_repos[repo_name] = {
+                    "error": f"Branch creation failed at {commit}: {exc}"
+                }
+                continue
+
+            try:
+                self._push_branch(repo_name, repo_dir)
+                successful_repos[repo_name] = {
+                    "url": url,
+                    "commit": commit,
+                    "branch": self.release_branch,
+                }
+            except subprocess.CalledProcessError as exc:
+                failed_repos[repo_name] = {"error": f"Branch push failed: {exc}"}
+
+        self.log(f"Summary: {len(successful_repos)} succeeded, {len(failed_repos)} failed out of {len(plan)} repos")
+        if successful_repos:
+            self.log(f"Successful repos: {pformat(successful_repos)}")
+        if failed_repos:
+            self.log(f"Failed repos: {pformat(failed_repos)}")
+
+    
+    def convert_to_ssh(self, url: str) -> str:
+        """Convert https://github.com/X/Y.git → git@github.com:X/Y.git"""
+        if url.startswith("https://github.com/"):
+            path = url.replace("https://github.com/", "")
+            return f"git@github.com:{path}"
+        return url
+
+    def tokenize_url(self, url: str) -> str:
+        """Return HTTPS+token URL if token provided, else SSH URL."""
+        if self.api_token:
+            return url.replace("https://", f"https://{self.api_token}@")
+        else:
+            # SSH mode → convert URL to SSH
+            return self.convert_to_ssh(url)
+
+    def get_submodule_url_map(self, repo_dir: Path) -> Dict[str, str]:
+        """Return mapping of submodule working-tree paths → remote URLs from .gitmodules."""
+        gitmodules_path = repo_dir / ".gitmodules"
+        if not gitmodules_path.exists():
+            return {}
+
+        try:
+            path_entries = self.run_command_output(
+                [
+                    "git", "config", "--file", str(gitmodules_path),
+                    "--get-regexp", r"submodule\..*\.path",
+                ],
+                cwd=repo_dir,
+            )
+        except subprocess.CalledProcessError:
+            return {}
+
+        url_map: Dict[str, str] = {}
+        for line in path_entries.splitlines():
+            # Each line is from `git config --get-regexp` and looks like:
+            #   "submodule.external/hipcc.path external/hipcc"
+            # We split into key="submodule.external/hipcc.path" and
+            # path_value="external/hipcc", then strip the trailing ".path"
+            # to get section="submodule.external/hipcc" for the URL lookup.
+            parts = line.strip().split(None, 1)
+            if len(parts) != 2:
+                continue
+            key, path_value = parts
+            section = key.rsplit(".", 1)[0]
+            try:
+                url = self.run_command_output(
+                    [
+                        "git", "config", "--file", str(gitmodules_path),
+                        "--get", f"{section}.url",
+                    ],
+                    cwd=repo_dir,
+                )
+            except subprocess.CalledProcessError:
+                self.log(f"No URL entry for {section}; skipping")
+                continue
+            url_map[path_value.strip()] = url
+
+        return url_map
+
+    def build_plan(self) -> Dict[str, Dict[str, str]]:
+        """
+        Build the branching execution plan.
+
+        1. Clone (or reuse cached clone of) TheRock.
+        2. Check out and hard-reset to ``self.commitid``.
+        3. Populate submodules via ``fetch_sources.py`` (or ``git submodule update``).
+        4. Read ``git submodule status`` and ``.gitmodules`` to collect each
+           submodule's commit SHA, remote URL, and local path.
+        5. Return a dict keyed by repo name, including TheRock itself.
+        """
+        cache_root = self.cache_dir or Path(tempfile.gettempdir()) / "rock-branching-cache"
+        cache_root.mkdir(parents=True, exist_ok=True)
+        clone_dir = cache_root / "TheRock"
+        self.cache_root = cache_root
+
+        # Ensure cache directory contains a valid git repo; otherwise reclone
+        needs_clone = not clone_dir.exists()
+        if not needs_clone and not (clone_dir / ".git").exists():
+            if not self.force_clone:
+                raise RuntimeError(
+                    f"Cache directory {clone_dir} exists but is not a git repo. "
+                    "Use --force-clone to delete it and reclone."
+                )
+            self.log(f"Cache directory {clone_dir} is not a git repo; removing before reclone (--force-clone)")
+            shutil.rmtree(clone_dir)
+            needs_clone = True
+
+        if needs_clone:
+            self.log(f"Cloning TheRock repo from {self.rock_url} into {clone_dir}")
+            self.run_command(
+                ["git", "clone", str(self.rock_url), str(clone_dir)],
+                cwd=cache_root,
+                stream=True,
+            )
+        else:
+            # Repo exists – ensure it's a valid git repo and has the right remote
+            self.log(f"Reusing existing TheRock repo at {clone_dir}")
+
+            # Optional: verify remote URL matches expected
+            try:
+                remote_url = self.run_command_output(
+                    ["git", "remote", "get-url", "origin"],
+                    cwd=clone_dir,
+                )
+                if "TheRock" not in remote_url:
+                    raise RuntimeError(
+                        f"Existing repo at {clone_dir} does not look like TheRock (origin={remote_url})"
+                    )
+            except subprocess.CalledProcessError as exc:
+                raise RuntimeError(f"Failed to inspect existing repo at {clone_dir}: {exc}") from exc
+
+            # Update refs from origin
+            self.log("Fetching latest changes for existing TheRock clone...")
+            self.run_command(["git", "fetch", "origin", "--prune", "--recurse-submodules=on-demand"], 
+                             cwd=clone_dir, stream=True)
+
+        fetch_script = clone_dir / "build_tools" / "fetch_sources.py"
+        rock_commit = self.commitid
+
+        # Hard-reset the working tree to the exact requested commit.
+        self.log(f"Checking out TheRock at commit {rock_commit}")
+        self.run_command(["git", "checkout", rock_commit], cwd=clone_dir)
+        self.run_command(["git", "reset", "--hard", rock_commit], cwd=clone_dir)
+
+        if fetch_script.exists():
+            self.log("Updating submodules via fetch_sources.py (jobs=10, no patches)...")
+            self.run_command(
+                ["python3", str(fetch_script), "--jobs", "10", "--no-apply-patches"],
+                cwd=clone_dir,
+                stream=True,
+            )
+        else:
+            self.log("fetch_sources.py not found; falling back to git submodule update")
+            self.run_command(
+                ["git", "submodule", "update", "--init", "--recursive"],
+                cwd=clone_dir,
+                stream=True,
+            )
+
+        # Read submodule SHAs at this commit
+        self.log("Reading submodule status...")
+        try:
+            status_output = self.run_command_output(
+                ["git", "submodule", "status"],
+                cwd=clone_dir,
+            )
+            lines = status_output.split("\n") if status_output else []
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to read submodule status: {exc}") from exc
+
+        # Parse .gitmodules to map paths → URLs
+        url_map = self.get_submodule_url_map(clone_dir)
+
+        plan: Dict[str, Dict[str, str]] = {}
+
+        # Each line from `git submodule status` looks like:
+        #   " <sha> <path> (<describe>)"  or  "-<sha> <path>" (not initialized)
+        # The leading character is ' ' (in-sync), '+' (changed), or '-' (not init).
+        for line in lines:
+            if not line:
+                continue
+
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            sha = parts[0].lstrip("-+")
+            path = parts[1]
+
+            repo_name = Path(path).name
+            repo_url = url_map.get(path)
+
+            if not repo_url:
+                self.log(f"No URL found for submodule {path} in .gitmodules")
+                continue
+
+            # Skip repos in the exclude list
+            if repo_name in self.exclude_list:
+                self.log(f"Skipping {repo_name} (in exclude list)")
+                continue
+
+            # Skip repos not under the ROCm organization
+            url_lower = repo_url.lower()
+            if "github.com/rocm/" not in url_lower and "github.com:rocm/" not in url_lower:
+                self.log(f"Skipping {repo_name} (not a ROCm org repo: {repo_url})")
+                continue
+
+            plan[repo_name] = {
+                "url": repo_url,
+                "commit": sha,
+                "path": str(clone_dir / path),
+            }
+
+        # Add TheRock itself to the plan
+        plan["TheRock"] = {
+            "url": self.rock_url,
+            "commit": rock_commit,
+            "path": str(clone_dir),
+        }
+
+        return plan
+
+    def main(self) -> None:
+        plan = self.build_plan()
+        self.log(f"Execution plan:\n{pformat(plan)}")
+        self.execute_plan(plan)
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Rock Branching Automation Tool"
+        )
+    parser.add_argument("-B", "--branch_name", required=True)
+    parser.add_argument(
+        "-C", "--commitid", required=True, help="Commit ID of TheRock"
+        )
+    parser.add_argument(
+        "-A", "--apitoken", required=False, help="GitHub API token (optional)"
+        )
+    parser.add_argument(
+        "--no-dry-run", action="store_false", dest="dry_run"
+        )
+    parser.add_argument(
+        "--exclude-list", nargs="*", default=[],
+        help="List of submodule repo names to exclude from branching"
+        )
+    parser.add_argument(
+        "--force-clone", action="store_true", default=False,
+        help="Delete and reclone if cache directory exists but is not a valid git repo"
+        )
+    parser.add_argument(
+        "--cache-dir", default=None,
+        help="Directory to cache the TheRock clone (default: /tmp/rock-branching-cache)"
+        )
+    parser.set_defaults(dry_run=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    RockBranchingAutomation(args).main()

--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -313,7 +313,6 @@ class RockBranchingAutomation:
         if failed_repos:
             self.log(f"Failed repos: {pformat(failed_repos)}")
 
-    
     def convert_to_ssh(self, url: str) -> str:
         """Convert https://github.com/X/Y.git → git@github.com:X/Y.git"""
         if url.startswith("https://github.com/"):
@@ -427,7 +426,7 @@ class RockBranchingAutomation:
 
             # Update refs from origin
             self.log("Fetching latest changes for existing TheRock clone...")
-            self.run_command(["git", "fetch", "origin", "--prune", "--recurse-submodules=on-demand"], 
+            self.run_command(["git", "fetch", "origin", "--prune", "--recurse-submodules=on-demand"],
                              cwd=clone_dir, stream=True)
 
         fetch_script = clone_dir / "build_tools" / "fetch_sources.py"


### PR DESCRIPTION
## Motivation

TheRock's release process requires creating release branches across TheRock and all its tracked ROCm submodules at a specific commit. Doing this manually is error-prone and time-consuming given the number of submodules involved. This script automates the entire workflow end-to-end.

## Technical Details

1. Implemented as RockBranchingAutomation class with two phases: plan building and plan execution.
2. build_plan() clones/caches TheRock, hard-resets to the target commit, populates submodules via fetch_sources.py (fallback: git submodule update), and parses .gitmodules + git submodule status to build a per-repo execution plan. Non-ROCm repos and --exclude-list entries are filtered out.
3. execute_plan() iterates each repo: sets up an authenticated rocm-github remote, checks for pre-existing branches via git ls-remote, creates the branch with git checkout -B, and pushes (unless dry-run).
4. Dry-run enabled by default; --no-dry-run enables actual pushes.

## Test Plan

1. Syntax validation: python3 -c "import py_compile; py_compile.compile('create_release_branch.py', doraise=True)"
2. Dry-run execution against a known TheRock commit to verify plan generation, submodule resolution, remote branch existence checks, and exclude-list filtering without pushing.
3. End-to-end test with --no-dry-run on a test fork to confirm branches are created and pushed correctly across all submodules.
4. Verify --force-clone correctly handles corrupted cache directories and --cache-dir overrides the default path.

## Test Result

1. Script compiles without errors.
2. Dry-run produces correct execution plan with expected submodule commits, URLs, and paths.
3. Excluded repos and non-ROCm repos are filtered from the plan.
4. Pre-existing remote branches are detected and the repo is skipped with a logged failure.
5. Cached clone reuse works across repeated runs via fetch/prune without recloning.
6. --force-clone deletes and reclones when the cache is not a valid git repo
