### PR TITLE
Enable 'schedule' trigger for multi_arch_release.yml

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -36,12 +36,10 @@ on:
         type: string
         default: ""
 
-  # TODO(https://github.com/ROCm/TheRock/issues/3334): Enable schedule for
-  # nightly releases once we're satisfied with dev releases and ready to advance
-
-  # schedule:
-  #   # Runs at 04:00 AM UTC, which is 8:00 PM PST (UTC-8)
-  #   - cron: '0 04 * * *'
+  # Trigger on a schedule to build nightly releases.
+  schedule:
+    # Runs at 02:00 AM UTC, which is 7:00 PM PST (UTC-8)
+    - cron: '0 02 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/3334.

## Technical Details

### Behavior details

This should choose to build for "all" target families, upload to `therock-nightly-artifacts`, then publish tarballs and python packages to `therock-nightly-*`. Once we add native linux packages and other files types to the release workflows they should be picked up too.

### Schedule time and runner load

This is the same schedule time as the existing nightly workflows:
* https://github.com/ROCm/TheRock/blob/main/.github/workflows/release_portable_linux_packages.yml
* https://github.com/ROCm/TheRock/blob/main/.github/workflows/release_windows_packages.yml

We'll be running duplicate nightly release builds until we complete the migration.

### Execution time comparison

I compared the execution time for the new workflows and the old workflows, see the full report at https://github.com/ScottTodd/claude-rocm-workspace/blob/main/reports/release_timing_comparison.md.

* Linux and Windows wall time is on par, with comparable bottlenecks
* Total time is substantially shorter (66h vs 86-102h) due to target-neutral stages only being built once
* The tarball and python package steps are serialized instead of running in parallel. We can iterate on the structure there

## Test Plan

* Test run with 'workflow_dispatch': https://github.com/ROCm/rockrel/actions/runs/24859053365
  * Built artifacts, tarballs, and python packages for all targets
  * Uploaded expected files to `therock-dev-artifacts`
  * Publish job failed (fix is https://github.com/ROCm/TheRock/pull/4792)
* I tried to add a more frequent schedule on my fork to test that triggering, but no jobs have been scheduled yet

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
