### PR TITLE
Update PyTorch/JAX versions + add gfx options

### DIFF
--- a/.github/workflows/release_portable_linux_jax_wheels.yml
+++ b/.github/workflows/release_portable_linux_jax_wheels.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         jax_ref: ["rocm-jaxlib-v0.8.2", "rocm-jaxlib-v0.9.0", "rocm-jaxlib-v0.9.1"]
 
     uses: ROCm/TheRock/.github/workflows/build_linux_jax_wheels.yml@main

--- a/.github/workflows/release_portable_linux_jax_wheels.yml
+++ b/.github/workflows/release_portable_linux_jax_wheels.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.11", "3.12", "3.13", "3.14"]
         jax_ref: ["rocm-jaxlib-v0.8.2", "rocm-jaxlib-v0.9.0", "rocm-jaxlib-v0.9.1"]
 
     uses: ROCm/TheRock/.github/workflows/build_linux_jax_wheels.yml@main

--- a/.github/workflows/release_portable_linux_jax_wheels.yml
+++ b/.github/workflows/release_portable_linux_jax_wheels.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13", "3.14"]
-        jax_ref: ["rocm-jaxlib-v0.8.0", "rocm-jaxlib-v0.8.2"]
+        jax_ref: ["rocm-jaxlib-v0.8.2", "rocm-jaxlib-v0.9.0", "rocm-jaxlib-v0.9.1"]
 
     uses: ROCm/TheRock/.github/workflows/build_linux_jax_wheels.yml@main
     with:

--- a/.github/workflows/release_portable_linux_pytorch_wheels.yml
+++ b/.github/workflows/release_portable_linux_pytorch_wheels.yml
@@ -14,6 +14,8 @@ on:
           - gfx1152
           - gfx1153
           - gfx120X-all
+          - gfx90a
+          - gfx908
           - gfx90X-dcgpu
           - gfx94X-dcgpu
           - gfx950-dcgpu
@@ -77,8 +79,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
-        pytorch_git_ref: ["release/2.7", "release/2.8", "release/2.9", "nightly"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        pytorch_git_ref: ["release/2.9", "release/2.10", "release/2.11"]
     uses: ROCm/TheRock/.github/workflows/build_portable_linux_pytorch_wheels.yml@main
     with:
       amdgpu_family: ${{ inputs.amdgpu_family }}

--- a/.github/workflows/release_windows_pytorch_wheels.yml
+++ b/.github/workflows/release_windows_pytorch_wheels.yml
@@ -76,8 +76,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.11", "3.12", "3.13"]
-        pytorch_git_ref: ["release/2.9"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
+        pytorch_git_ref: ["release/2.9", "release/2.10", "release/2.11"]
 
     uses: ROCm/TheRock/.github/workflows/build_windows_pytorch_wheels.yml@main
     with:


### PR DESCRIPTION
Updates the release matrix for PyTorch and JAX versions and allows to build for gfx90a and gfx908 instead of building for the gfx90X family target.