### PR TITLE
Add .github/workflows/test_artifacts.yml wrapper workflow

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -4,10 +4,6 @@
 # Thin wrapper that dispatches to TheRock's test_artifacts.yml.
 # This exists so that release workflows running in rockrel's context
 # can dispatch test runs to this repo (which then calls TheRock).
-#
-# Note: workflow_dispatch has a 10-input limit. Inputs not needed for
-# release dispatch (benchmark_runs_on, sanity_check_only_for_family,
-# run_extended_tests) use their defaults from TheRock's workflow.
 
 name: Test Artifacts
 
@@ -26,12 +22,25 @@ on:
         default: ""
       test_runs_on:
         type: string
+      benchmark_runs_on:
+        type: string
+        default: ""
+      sanity_check_only_for_family:
+        type: boolean
+        default: false
       test_type:
         type: string
       test_labels:
         type: string
         default: ""
+      run_extended_tests:
+        type: string
+        default: 'false'
+      windows_hip_rocr_tests:
+        type: string
+        default: 'false'
       release_type:
+        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
         type: string
         default: ""
       repository:
@@ -51,14 +60,19 @@ run-name: Test Artifacts (${{ inputs.amdgpu_families }})
 jobs:
   test:
     uses: ROCm/TheRock/.github/workflows/test_artifacts.yml@main
+    secrets: inherit
     with:
       artifact_group: ${{ inputs.artifact_group }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       amdgpu_targets: ${{ inputs.amdgpu_targets }}
       test_runs_on: ${{ inputs.test_runs_on }}
+      benchmark_runs_on: ${{ inputs.benchmark_runs_on }}
+      sanity_check_only_for_family: ${{ inputs.sanity_check_only_for_family }}
       test_type: ${{ inputs.test_type }}
       test_labels: ${{ inputs.test_labels }}
+      run_extended_tests: ${{ inputs.run_extended_tests }}
+      windows_hip_rocr_tests: ${{ inputs.windows_hip_rocr_tests }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -55,7 +55,7 @@ on:
 permissions:
   contents: read
 
-run-name: Test Artifacts (${{ inputs.amdgpu_families }})
+run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
 
 jobs:
   test:

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -1,0 +1,64 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Thin wrapper that dispatches to TheRock's test_artifacts.yml.
+# This exists so that release workflows running in rockrel's context
+# can dispatch test runs to this repo (which then calls TheRock).
+#
+# Note: workflow_dispatch has a 10-input limit. Inputs not needed for
+# release dispatch (benchmark_runs_on, sanity_check_only_for_family,
+# run_extended_tests) use their defaults from TheRock's workflow.
+
+name: Test Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_group:
+        type: string
+      artifact_run_id:
+        type: string
+        default: ""
+      amdgpu_families:
+        type: string
+      amdgpu_targets:
+        type: string
+        default: ""
+      test_runs_on:
+        type: string
+      test_type:
+        type: string
+      test_labels:
+        type: string
+        default: ""
+      release_type:
+        type: string
+        default: ""
+      repository:
+        description: "TheRock repository to checkout."
+        type: string
+        default: "ROCm/TheRock"
+      ref:
+        description: "Branch, tag, or SHA to checkout in TheRock."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+run-name: Test Artifacts (${{ inputs.amdgpu_families }})
+
+jobs:
+  test:
+    uses: ROCm/TheRock/.github/workflows/test_artifacts.yml@main
+    with:
+      artifact_group: ${{ inputs.artifact_group }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      amdgpu_targets: ${{ inputs.amdgpu_targets }}
+      test_runs_on: ${{ inputs.test_runs_on }}
+      test_type: ${{ inputs.test_type }}
+      test_labels: ${{ inputs.test_labels }}
+      release_type: ${{ inputs.release_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - id: forbid-tabs
 
 - repo: https://github.com/rhysd/actionlint
-  rev: v1.7.9
+  rev: v1.7.10
   hooks:
     - id: actionlint
       args: [-shellcheck=, -ignore, 'label ".+" is unknown']


### PR DESCRIPTION
## Motivation

Prerequisite for https://github.com/ROCm/TheRock/pull/5212.

Progress on https://github.com/ROCm/TheRock/issues/2281. This will be used to switch release workflows from spawning "test artifacts" workflow jobs in _the current workflow_ to triggering _separate workflows_ using workflow dispatch, one per GPU target/family.

## Test Plan

* Testing the workflow_dispatch of this workflow at https://github.com/ROCm/TheRock/actions/runs/25752660761 in TheRock
* Testing this wrapper workflow is harder (could trigger a dev release after the wrapper workflow is available)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
