### PR TITLE
Bump actionlint to v1.7.10 for workflow_dispatch input limit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - id: forbid-tabs
 
 - repo: https://github.com/rhysd/actionlint
-  rev: v1.7.9
+  rev: v1.7.10
   hooks:
     - id: actionlint
       args: [-shellcheck=, -ignore, 'label ".+" is unknown']


### PR DESCRIPTION
## Motivation

https://github.com/rhysd/actionlint/releases/tag/v1.7.10 has
> Increase the maximum number of inputs in the workflow_dispatch event from 10 to 25 because the limitation [was recently relaxed](https://github.blog/changelog/2025-12-04-actions-workflow-dispatch-workflows-now-support-25-inputs/).

and I'd like to use the higher limit in https://github.com/ROCm/rockrel/pull/44 for `test_artifacts.yml`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
