### PR TITLE
Add full PyTorch test release wrapper

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -58,6 +58,7 @@ jobs:
       prerelease_version: ${{ inputs.prerelease_version || '' }}
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'all' }}
       windows_amdgpu_families: ${{ inputs.windows_amdgpu_families || 'all' }}
+      run_full_pytorch_tests: ${{ github.event_name == 'schedule' }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
     permissions:

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -33,6 +33,10 @@ on:
           - sccache
           - ccache
         default: none
+      run_full_pytorch_tests:
+        description: Run full PyTorch tests after scheduled nightly wheel builds complete.
+        type: boolean
+        default: false
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string
@@ -53,5 +57,6 @@ jobs:
       rocm_package_find_links_url: ${{ inputs.rocm_package_find_links_url }}
       release_type: ${{ inputs.release_type }}
       cache_type: ${{ inputs.cache_type }}
+      run_full_pytorch_tests: ${{ inputs.run_full_pytorch_tests }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -1,0 +1,82 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Thin wrapper that dispatches to TheRock's test_pytorch_wheels_full.yml.
+# This exists so release workflows running in rockrel can dispatch the
+# workflow by name in this repository, then run the reusable workflow from
+# TheRock with explicit checkout plumbing.
+
+name: Test PyTorch Wheels (Full Suite)
+
+on:
+  workflow_dispatch:
+    inputs:
+      amdgpu_family:
+        type: string
+        required: true
+        default: "gfx94X-dcgpu"
+      test_runs_on:
+        type: string
+        required: true
+        default: "linux-gfx942-1gpu-ossci-rocm"
+      test_runs_on_multi_gpu:
+        type: string
+        default: "linux-gfx942-8gpu-ossci-rocm"
+      package_index_url:
+        type: string
+        required: true
+        default: "https://rocm.nightlies.amd.com/v4/whl-staging"
+      python_version:
+        type: string
+        required: true
+        default: "3.12"
+      torch_version:
+        type: string
+        required: true
+      pytorch_git_ref:
+        type: string
+        default: "nightly"
+      pytorch_git_repo:
+        type: string
+        default: "pytorch/pytorch"
+      test_configs:
+        type: string
+        default: "default distributed inductor"
+      tests_to_include:
+        type: string
+        default: ""
+      multi_arch:
+        type: boolean
+        default: true
+      repository:
+        description: "TheRock repository to checkout."
+        type: string
+        default: "ROCm/TheRock"
+      ref:
+        description: "Branch, tag, or SHA to checkout in TheRock."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+run-name: Test PyTorch Full (${{ inputs.amdgpu_family }}, ${{ inputs.torch_version }}, ${{ inputs.test_runs_on }})
+
+jobs:
+  test:
+    uses: ROCm/TheRock/.github/workflows/test_pytorch_wheels_full.yml@main
+    secrets: inherit
+    with:
+      amdgpu_family: ${{ inputs.amdgpu_family }}
+      test_runs_on: ${{ inputs.test_runs_on }}
+      test_runs_on_multi_gpu: ${{ inputs.test_runs_on_multi_gpu }}
+      package_index_url: ${{ inputs.package_index_url }}
+      python_version: ${{ inputs.python_version }}
+      torch_version: ${{ inputs.torch_version }}
+      pytorch_git_ref: ${{ inputs.pytorch_git_ref }}
+      pytorch_git_repo: ${{ inputs.pytorch_git_repo }}
+      test_configs: ${{ inputs.test_configs }}
+      tests_to_include: ${{ inputs.tests_to_include }}
+      multi_arch: ${{ inputs.multi_arch }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}


### PR DESCRIPTION
Companion to ROCm/TheRock#4499 (merged).

Threads `run_full_pytorch_tests` through the scheduled multi-arch nightly release path and adds a `test_pytorch_wheels_full.yml` wrapper so release workflows running in rockrel can dispatch the full PyTorch test suite by name.

- `multi_arch_release.yml`: opt into full tests for scheduled (nightly) releases only, via `run_full_pytorch_tests: ${{ github.event_name == 'schedule' }}`.
- `multi_arch_release_linux_pytorch_wheels.yml`: accept and forward `run_full_pytorch_tests` to TheRock's reusable workflow.
- `test_pytorch_wheels_full.yml`: thin wrapper that runs TheRock's reusable `test_pytorch_wheels_full.yml` with explicit `repository`/`ref` checkout plumbing.

Merge order: lands after TheRock#4499 (now merged), which defines the `run_full_pytorch_tests` input consumed here.
