### PR TITLE
Update cron job time for multi arch release job

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -38,8 +38,8 @@ on:
 
   # Trigger on a schedule to build nightly releases.
   schedule:
-    # Runs at 02:00 AM UTC, which is 7:00 PM PST (UTC-8)
-    - cron: '0 02 * * *'
+    # Runs at 12:00 AM UTC, which is 5:00 PM PDT (UTC-7)
+    - cron: '0 00 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
 
Updates the scheduled trigger time for the Multi-Arch Release workflow. This will give enough time for QA India and other teams from BKC to kick off the builds for efficient testing time. Agreed by Stella and Arsen on the times.
 
## Changes
 
- Changed the nightly schedule from `02:00 UTC` to `00:00 UTC`.
- This moves the intended trigger time from `7:00 PM PDT` to `5:00 PM PDT`.
- Updated the schedule comment to reflect the new UTC/PDT timing.
 
## Notes
 
GitHub Actions scheduled workflows may not start exactly at the cron time due to queueing or platform delays, but the requested trigger time is now `00:00 UTC`.