### PR TITLE
Add .github/workflows/test_native_linux_packages_install wrapper workflow

### DIFF
--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -15,26 +15,17 @@ on:
         required: true
         type: string
       release_type:
-        description: "Release line (ci, dev, nightly, or prerelease)."
+        description: "Release Type (ci, dev, nightly, prerelease)."
         required: true
-        type: choice
-        options:
-          - ci
-          - dev
-          - nightly
-          - prerelease
+        type: string
       gpg_key_url:
         description: "GPG key URL for signed repos"
         type: string
         default: ""
       os_profile:
-        description: "OS profile (package type deb/rpm is derived from this)."
+        description: "OS profile (e.g., ubuntu2404, rhel10, sles16). Package type (deb/rpm) is derived from this."
         required: true
-        type: choice
-        options:
-          - ubuntu2404
-          - rhel10
-          - sles16
+        type: string
       artifact_group:
         description: "Artifact group to extract GPU architecture from (e.g., gfx94X-dcgpu)."
         type: string
@@ -48,11 +39,11 @@ on:
         type: string
         default: ""
       repository:
-        description: "TheRock repository to checkout."
+        description: "Repository to checkout. Otherwise, defaults to `github.repository`"
         type: string
         default: "ROCm/TheRock"
       ref:
-        description: "Branch, tag, or SHA to checkout in TheRock."
+        description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow"
         type: string
         default: ""
 

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -1,0 +1,78 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Thin wrapper that dispatches to TheRock's test_native_linux_packages_install.yml.
+# This exists so that release workflows running in rockrel's context
+# can dispatch native Linux package install tests to TheRock.
+
+name: Test Native Linux Packages Install
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_install_url:
+        description: "Package installation URL (includes architecture subdirectory for RPM)."
+        required: true
+        type: string
+      release_type:
+        description: "Release line (ci, dev, nightly, or prerelease)."
+        required: true
+        type: choice
+        options:
+          - ci
+          - dev
+          - nightly
+          - prerelease
+      gpg_key_url:
+        description: "GPG key URL for signed repos"
+        type: string
+        default: ""
+      os_profile:
+        description: "OS profile (package type deb/rpm is derived from this)."
+        required: true
+        type: choice
+        options:
+          - ubuntu2404
+          - rhel10
+          - sles16
+      artifact_group:
+        description: "Artifact group to extract GPU architecture from (e.g., gfx94X-dcgpu)."
+        type: string
+        default: "gfx94X-dcgpu"
+      install_prefix:
+        description: "Installation prefix path."
+        type: string
+        default: "/opt/rocm/core"
+      test_type:
+        description: "Test type: quick, standard, comprehensive, full, install, or sanity."
+        type: string
+        default: ""
+      repository:
+        description: "TheRock repository to checkout."
+        type: string
+        default: "ROCm/TheRock"
+      ref:
+        description: "Branch, tag, or SHA to checkout in TheRock."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+run-name: Test Native Linux Packages Install (${{ inputs.os_profile }}, ${{ inputs.release_type }}, ${{ inputs.test_type || 'sanity' }})
+
+jobs:
+  test:
+    uses: ROCm/TheRock/.github/workflows/test_native_linux_packages_install.yml@main
+    secrets: inherit
+    with:
+      package_install_url: ${{ inputs.package_install_url }}
+      release_type: ${{ inputs.release_type }}
+      gpg_key_url: ${{ inputs.gpg_key_url }}
+      os_profile: ${{ inputs.os_profile }}
+      artifact_group: ${{ inputs.artifact_group }}
+      install_prefix: ${{ inputs.install_prefix }}
+      test_type: ${{ inputs.test_type }}
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Motivation

This pull request introduces a new GitHub Actions workflow file to the repository. The workflow acts as a thin wrapper to dispatch native Linux package installation tests to a shared workflow in the `ROCm/TheRock` repository. This enables release workflows running in the `rockrel` context to trigger package installation tests in a standardized way.

## Technical Details

* Added `.github/workflows/test_native_linux_packages_install.yml`, which defines a workflow for dispatching native Linux package installation tests to the `ROCm/TheRock` repository, with configurable inputs for package URLs, OS profiles, release types, and more. This facilitates consistent and flexible testing of Linux package installations across different release types and environments.


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

https://github.com/ROCm/rockrel/actions/runs/27044375717
Testing this wrapper workflow is harder (could trigger a dev release after the wrapper workflow is available)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
