### PR TITLE
Add stub workflow for multi-arch JAX release dispatch

### DIFF
--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -18,10 +18,6 @@ on:
         description: URL to the shared TheRock tarball used for the build.
         type: string
         required: true
-      repository:
-        description: Repository to checkout. Defaults to github.repository.
-        type: string
-        default: ""
       ref:
         description: Branch, tag, or SHA to checkout.
         type: string
@@ -40,10 +36,6 @@ on:
         description: URL to the shared TheRock tarball used for the build.
         type: string
         required: true
-      repository:
-        description: Repository to checkout. Defaults to github.repository.
-        type: string
-        default: ""
       ref:
         description: Branch, tag, or SHA to checkout.
         type: string

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -1,0 +1,67 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+name: Multi-Arch Release Linux JAX Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type: "dev", "nightly", or "prerelease".'
+        type: string
+        required: true
+      rocm_version:
+        description: ROCm package version to build against.
+        type: string
+        required: true
+      tar_url:
+        description: URL to the shared TheRock tarball used for the build.
+        type: string
+        required: true
+      repository:
+        description: Repository to checkout. Defaults to github.repository.
+        type: string
+        default: ""
+      ref:
+        description: Branch, tag, or SHA to checkout.
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      release_type:
+        description: 'Release type: "dev", "nightly", or "prerelease".'
+        type: string
+        required: true
+      rocm_version:
+        description: ROCm package version to build against.
+        type: string
+        required: true
+      tar_url:
+        description: URL to the shared TheRock tarball used for the build.
+        type: string
+        required: true
+      repository:
+        description: Repository to checkout. Defaults to github.repository.
+        type: string
+        default: ""
+      ref:
+        description: Branch, tag, or SHA to checkout.
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, multiarch)
+
+jobs:
+  build_jax_wheels:
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
+    secrets: inherit
+    with:
+      release_type: ${{ inputs.release_type }}
+      rocm_version: ${{ inputs.rocm_version }}
+      tar_url: ${{ inputs.tar_url }}
+      repository: ${{ inputs.repository || github.repository }}
+      ref: ${{ inputs.ref || github.ref_name }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -53,7 +53,7 @@ permissions:
   contents: read
   id-token: write
 
-run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, multiarch)
+run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, Multiarch)
 
 jobs:
   build_jax_wheels:
@@ -63,5 +63,5 @@ jobs:
       release_type: ${{ inputs.release_type }}
       rocm_version: ${{ inputs.rocm_version }}
       tar_url: ${{ inputs.tar_url }}
-      repository: ${{ inputs.repository || github.repository }}
-      ref: ${{ inputs.ref || github.ref_name }}
+      repository: "ROCm/TheRock"
+      ref: ${{ inputs.ref || '' }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -22,24 +22,6 @@ on:
         description: Branch, tag, or SHA to checkout.
         type: string
         default: ""
-  workflow_call:
-    inputs:
-      release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
-        type: string
-        required: true
-      rocm_version:
-        description: ROCm package version to build against.
-        type: string
-        required: true
-      tar_url:
-        description: URL to the shared TheRock tarball used for the build.
-        type: string
-        required: true
-      ref:
-        description: Branch, tag, or SHA to checkout.
-        type: string
-        default: ""
 
 permissions:
   contents: read


### PR DESCRIPTION
# Motivation

Prerequisite for ROCm/TheRock JAX multi-arch release workflow integration.

TheRock's multi-arch Linux release workflow dispatches downstream workflows using `benc-uk/workflow-dispatch`. When the release entry point runs in ROCm/rockrel, dispatched workflows must exist in the rockrel repository as forwarding stubs.

This PR adds the forwarding workflow required for:

`multi_arch_release_linux_jax_wheels.yml`

and should land before the corresponding TheRock change that dispatches it.

Related:

* ROCm/TheRock PR: <link to your TheRock PR>
* Similar pattern: ROCm/rockrel#44
* Similar dependency sequencing: TheRock #5212

# Technical Details

Adds:

```text
.github/workflows/multi_arch_release_linux_jax_wheels.yml
```

This workflow is a thin forwarding wrapper that delegates to:

```text
ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
```

and forwards:

* `release_type`
* `rocm_version`
* `tar_url`
* `repository`
* `ref`

No functional behavior changes are introduced in rockrel beyond enabling workflow-dispatch for the JAX release workflow.
