### PR TITLE
Allow ROCm packages from a PEP 503 index (e.g. repo.amd.com)

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -50,7 +50,7 @@ run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}
 
 jobs:
   release:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@ethanwee/pytorch-wheels-rocm-index-url
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -14,9 +14,13 @@ on:
         type: string
         required: true
       rocm_package_find_links_url:
-        description: URL for pip --find-links to install ROCm packages
+        description: URL for pip --find-links to install ROCm packages (flat page; use this OR rocm_package_index_url)
         type: string
-        required: true
+        default: ""
+      rocm_package_index_url:
+        description: URL for pip --index-url to install ROCm packages (PEP 503 index, e.g. https://repo.amd.com/rocm/whl-multi-arch/; use this OR rocm_package_find_links_url)
+        type: string
+        default: ""
       release_type:
         description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
         type: choice
@@ -51,6 +55,7 @@ jobs:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       rocm_version: ${{ inputs.rocm_version }}
       rocm_package_find_links_url: ${{ inputs.rocm_package_find_links_url }}
+      rocm_package_index_url: ${{ inputs.rocm_package_index_url }}
       release_type: ${{ inputs.release_type }}
       cache_type: ${{ inputs.cache_type }}
       repository: "ROCm/TheRock"


### PR DESCRIPTION
## Summary

Adds optional `rocm_package_index_url` to the rockrel multi-arch PyTorch wheel release workflow so ROCm packages can be installed from a **PEP 503 simple index** (e.g. `https://repo.amd.com/rocm/whl-multi-arch/`) instead of only a flat `--find-links` page.

## Changes

- `multi_arch_release_linux_pytorch_wheels.yml`: new `rocm_package_index_url` input; either index URL or find-links URL can be supplied
- Pins the reusable workflow to a TheRock branch that implements index-url support in the build pipeline

## Why

Some AMD ROCm package hosts expose wheels via PEP 503 index layout rather than a single flat HTML find-links page. This lets release dispatches target those indexes without manual URL workarounds.
