### PR TITLE
[ci] Adding `python_version` to release linux PyTorch wheels

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -55,3 +55,4 @@ jobs:
       cache_type: ${{ inputs.cache_type }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
+      python_version: ""

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -55,3 +55,4 @@ jobs:
       cache_type: ${{ inputs.cache_type }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
+      python_version: ""


### PR DESCRIPTION
After this update: https://github.com/ROCm/TheRock/commit/dd5db8174f9a4f10725469e3641c15a7a5cb8da7, noticing error: https://github.com/ROCm/rockrel/actions/runs/27227313222/job/80440361861#step:2:22

Was missing new argument (`python_version`)

Fixed here: https://github.com/ROCm/rockrel/actions/runs/27288075393/job/80600746523 (cancelled to save resources)