### PR TITLE
Declare `python_version` in workflow_dispatch

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -37,6 +37,10 @@ on:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string
         default: ''
+      python_version:
+        description: "Single Python version to build (empty for full matrix)"
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -55,4 +59,4 @@ jobs:
       cache_type: ${{ inputs.cache_type }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
-      python_version: ""
+      python_version: ${{ inputs.python_version }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -37,6 +37,10 @@ on:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string
         default: ''
+      python_version:
+        description: "Single Python version to build (empty for full matrix)"
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -55,4 +59,4 @@ jobs:
       cache_type: ${{ inputs.cache_type }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
-      python_version: ""
+      python_version: ${{ inputs.python_version }}


### PR DESCRIPTION
## Motivation

PR #54 fixed the "missing argument" error by passing `python_version: ""` hardcoded into the reusable workflow call. This is enough to stop the error when `python_version` is absent, but it missed to declare the input on the workflow_dispatch trigger itself. When an orchestrator (multi_arch_release_linux.yml) dispatches this workflow and passes `python_version` explicitly, GitHub rejects the dispatch because the input is undeclared:
https://github.com/ROCm/rockrel/actions/runs/27315369389/job/80726867133#step:2:19

## Technical Details

This declares `python_version` as a proper workflow_dispatch input (default '') and threads it through on both linux and windows, so orchestrators can override it and manual dispatch exposes the option too.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.