### PR TITLE
Declare `repository` as workflow_dispatch input

### DIFF
--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -22,6 +22,10 @@ on:
         description: Branch, tag, or SHA to checkout.
         type: string
         default: ""
+      repository:
+        description: "Repository to checkout. Defaults to ROCm/TheRock."
+        type: string
+        default: "ROCm/TheRock"
 
 permissions:
   contents: read
@@ -37,5 +41,5 @@ jobs:
       release_type: ${{ inputs.release_type }}
       rocm_version: ${{ inputs.rocm_version }}
       tar_url: ${{ inputs.tar_url }}
-      repository: "ROCm/TheRock"
+      repository: ${{ inputs.repository || 'ROCm/TheRock' }}
       ref: ${{ inputs.ref || '' }}


### PR DESCRIPTION
## Motivation

`repository` was hardcoded as "ROCm/TheRock" in the reusable workflow call but not declared as a workflow_dispatch input. When TheRock's `multi_arch_release_linux.yml` dispatches this workflow and passes repository explicitly, GitHub rejects it:
https://github.com/ROCm/rockrel/actions/runs/27315369389/job/80726867133#step:2:19

## Technical Details

Declares `repository` as a proper workflow_dispatch input (default "ROCm/TheRock") and thread it through.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.