### PR TITLE
ci: grant actions: write to Linux PyTorch wheels caller

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -49,6 +49,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: write
 
 run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
 


### PR DESCRIPTION
## Problem
Dispatches of `multi_arch_release_linux_pytorch_wheels.yml` are failing with `startup_failure`:

> Error calling workflow 'ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@main'. The nested job 'dispatch_pytorch_wheels_full_test' is requesting 'actions: write', but is only allowed 'actions: none'.

TheRock's reusable workflow (pinned `@main`) recently added a nested `dispatch_pytorch_wheels_full_test` job (TheRock PR #4499) that needs `actions: write` to dispatch the downstream full PyTorch test workflow. This caller only granted `id-token: write` + `contents: read`, so `actions` was implicitly `none` and GitHub rejected the workflow at parse time — no jobs ran, including the wheel builds.

Examples: rockrel runs 27363051381, 27377320968 (startup_failure). The June 8 run (27159578424) passed only because it predated the TheRock change.

## Fix
Add `actions: write` to the `permissions:` block so the nested job validates.

## Test plan
- [ ] Re-dispatch `Multi-Arch Release Linux PyTorch Wheels` on this branch and confirm it no longer `startup_failure`s and the `build_pytorch_wheels` matrix runs.

Made with [Cursor](https://cursor.com)