### PR TITLE
[CI] Fix: Add actions:write permission for PyTorch wheel release workflow

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -49,6 +49,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: write
 
 run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
 


### PR DESCRIPTION

  ## Motivation

  The `multi_arch_release_linux_pytorch_wheels.yml` workflow in rockrel fails at startup, preventing PyTorch wheel releases from being built. The failure occurs because the workflow lacks the required `actions: write` permission needed by the downstream job that orchestrates test execution.
  This fix enables the release workflow to successfully start and dispatch test workflows across multiple PyTorch versions.

  ## Technical Details

  **Root Cause:** The rockrel wrapper delegates to TheRock's reusable workflow. Within that workflow, the `dispatch_pytorch_wheels_full_test` job uses the `benck-uk/workflow-dispatch` action to programmatically trigger test_pytorch_wheels_full.yml` via the GitHub Actions API. This operation requires the `actions: write` permission.

  **Solution:** Added `actions: write` to the permissions block in github/workflows/multi_arch_release_linux_pytorch_wheels.yml` (line 52):

  ```yaml
  permissions:
    id-token: write
    contents: read
    actions: write  # ← NEW
```
## Test Result
https://github.com/ROCm/rockrel/actions/runs/27410098861  - run started successfully and triggered downstream jobs. 
(cancelled the job to save resources)