### PR TITLE
Add `test_amdgpu_family` input to JAX release workflow

### DIFF
--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -6,6 +6,10 @@ name: Multi-Arch Release Linux JAX Wheels
 on:
   workflow_dispatch:
     inputs:
+      test_amdgpu_family:
+        description: "GPU family to use for JAX tests; empty means skip tests."
+        type: string
+        default: ""
       release_type:
         description: 'Release type: "dev", "nightly", or "prerelease".'
         type: string
@@ -38,6 +42,7 @@ jobs:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
     secrets: inherit
     with:
+      test_amdgpu_family: ${{ inputs.test_amdgpu_family }}
       release_type: ${{ inputs.release_type }}
       rocm_version: ${{ inputs.rocm_version }}
       tar_url: ${{ inputs.tar_url }}


### PR DESCRIPTION
## Motivation
To align with JAX test integration PR: https://github.com/ROCm/TheRock/pull/5801
we are adding `test_amdgpu_family` to the JAX multi-arch release workflow dispatch inputs and propagate it to TheRock.

This keeps the JAX release workflow aligned with the updated TheRock workflow, where the test target GPU family is treated as test configuration rather than a build target configuration.