### PR TITLE
Grant packages read permission to JAX release workflow

### DIFF
--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -33,6 +33,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   id-token: write
 
 run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, Multiarch)

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -40,7 +40,7 @@ run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ i
 
 jobs:
   build_jax_wheels:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/fix-jax-target-run-checkout
     secrets: inherit
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -39,7 +39,7 @@ run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ i
 
 jobs:
   build_jax_wheels:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/fix-jax-target-run-checkout
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/add-packages-read
     secrets: inherit
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -39,7 +39,7 @@ run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ i
 
 jobs:
   build_jax_wheels:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/fix-jax-target-run-checkout
     secrets: inherit
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -39,7 +39,7 @@ run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ i
 
 jobs:
   build_jax_wheels:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/add-packages-read
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/fix-jax-workflow-permissions
     secrets: inherit
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -40,7 +40,7 @@ run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ i
 
 jobs:
   build_jax_wheels:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/fix-jax-target-run-checkout
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
     secrets: inherit
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -33,7 +33,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
   id-token: write
 
 run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, Multiarch)

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -33,14 +33,13 @@ on:
 
 permissions:
   contents: read
-  packages: read
   id-token: write
 
 run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, Multiarch)
 
 jobs:
   build_jax_wheels:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@users/erman-gurses/fix-jax-target-run-checkout
     secrets: inherit
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}


### PR DESCRIPTION
## Summary

Grant `packages: read` permission to the RockRel multi-arch JAX release workflow.

The reusable workflow invoked from `ROCm/TheRock` requests `packages: read`, but the caller workflow did not grant that permission. GitHub Actions rejects the workflow invocation with:

Error: https://github.com/ROCm/rockrel/actions/runs/27806016125

```
The nested job 'build_jax_wheels' is requesting 'packages: read', but is only allowed 'packages: none'
```

## Changes

* Add `packages: read` to the top-level workflow permissions in:

  * `.github/workflows/multi_arch_release_linux_jax_wheels.yml`

