### PR TITLE
Fix native Linux package install instructions for multi-arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ After downloading, extract the release tarball into place:
 ```bash
 mkdir therock-tarball && cd therock-tarball
 
-# Per-family (smaller, one GPU family):
-wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-gfx94X-dcgpu-7.14.0rc1.tar.gz
+# Multiarch (all GPUs):
+wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0rc1.tar.gz
 
-# Or multiarch (all GPUs):
-# wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0rc1.tar.gz
+# Per-family (smaller, one GPU family):
+# wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-gfx94X-dcgpu-7.14.0rc1.tar.gz
 
 mkdir install
 tar -xf *.tar.gz -C install
@@ -91,6 +91,7 @@ tar -xf *.tar.gz -C install
 Pick the tarball that matches your GPU family and ROCm version from the index
 (e.g. `gfx1151`, `gfx950-dcgpu`). Use the `multiarch` tarball to install all
 supported GPU families at once.
+
 #### Installing from Native Linux Packages
 
 AMD provides prerelease ROCm packages for both Debian-based and RPM-based Linux distributions.
@@ -118,7 +119,7 @@ wget https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg -O - \
 ###### Add the ROCm Repository
 
 The example below uses the `ubuntu2404` profile; change it to match your
-distribution (e.g. `debian12`, `ubuntu2204`).
+distribution (e.g. `debian12`, `ubuntu2204`, `ubuntu2604`).
 
 ```bash
 sudo tee /etc/apt/sources.list.d/rocm.list << EOF
@@ -140,12 +141,12 @@ sudo apt install amdrocm-core
 
 ---
 
-##### Installing Packages on RHEL-Based Systems
+##### Installing Packages on RPM-Based Systems
 
 ###### Add the ROCm Repository
 
 The example below uses the `rhel10` profile; change it to match your
-distribution (e.g. `rhel8`, `rhel9`).
+distribution (e.g. `rhel8`, `rhel9`, `sles15`, `sles16`).
 
 ```bash
 sudo tee /etc/yum.repos.d/rocm.repo << EOF
@@ -168,30 +169,4 @@ sudo dnf clean all
 sudo dnf install amdrocm-core
 # For a specific ROCm version and GPU arch instead, e.g.:
 # sudo dnf install amdrocm7.14-gfx942
-```
-
----
-
-##### Installing Packages on SLES-Based Systems
-
-SLES uses `zypper` rather than `dnf`. The example below uses the `sles15`
-profile; change it to match your distribution (e.g. `sles16`).
-
-###### Add the ROCm Repository
-
-```bash
-sudo rpm --import https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
-sudo zypper addrepo --gpgcheck --refresh https://rocm.prereleases.amd.com/packages-multi-arch/sles15/x86_64/ rocm
-sudo zypper --gpg-auto-import-keys refresh
-```
-
----
-
-###### Install ROCm
-
-```bash
-# Installs the full ROCm core SDK (version- and architecture-independent).
-sudo zypper install amdrocm-core
-# For a specific ROCm version and GPU arch instead, e.g.:
-# sudo zypper install amdrocm7.14-gfx942
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ AMD provides prerelease ROCm packages for both Debian-based and RPM-based Linux 
 Repository base URL:
 
 ```
-https://rocm.prereleases.amd.com/packages/
+https://rocm.prereleases.amd.com/packages-multi-arch/
 ```
 
 ---
@@ -119,7 +119,7 @@ Replace `<os_profile>` with the appropriate distribution profile
 
 ```bash
 sudo tee /etc/apt/sources.list.d/rocm.list << EOF
-deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://rocm.prereleases.amd.com/packages/<os_profile> stable main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://rocm.prereleases.amd.com/packages-multi-arch/<os_profile> stable main
 EOF
 sudo apt update
 ```
@@ -129,7 +129,7 @@ sudo apt update
 ###### Install ROCm
 
 ```bash
-sudo apt install amdrocm-gfx94x # Change the gfx arch based on your machine.
+sudo apt install amdrocm7.14-gfx942 # Change the version (7.14) and gfx arch (gfx942) based on your release and machine.
 ```
 
 ---
@@ -145,7 +145,7 @@ Replace `<os_profile>` with the appropriate distribution profile
 sudo tee /etc/yum.repos.d/rocm.repo << EOF
 [rocm]
 name=ROCm Prerelease Repository
-baseurl=https://rocm.prereleases.amd.com/packages/<os_profile>/x86_64/
+baseurl=https://rocm.prereleases.amd.com/packages-multi-arch/<os_profile>/x86_64/
 enabled=1
 gpgcheck=1
 gpgkey=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
@@ -158,5 +158,5 @@ sudo dnf clean all
 ###### Install ROCm
 
 ```bash
-sudo dnf install amdrocm-gfx94x # Change the gfx arch based on your machine.
+sudo dnf install amdrocm7.14-gfx942 # Change the version (7.14) and gfx arch (gfx942) based on your release and machine.
 ```

--- a/README.md
+++ b/README.md
@@ -42,15 +42,17 @@ For general and more detailed information on releases, see [`RELEASES.md` in The
 
 #### Installing ROCm Python packages
 
-Multi-arch releases use a single index URL for all GPU architectures. Select
-your GPU using a pip `[device-*]` extra:
+Multi-arch releases use a single index URL for all GPU architectures. Use
+`device-all` for all supported GPUs, or one family with a `[device-*]` extra:
 
 ```bash
 pip install --index-url https://rocm.prereleases.amd.com/whl-multi-arch/ --pre \
-  "rocm[libraries,devel,device-gfx942]"
+  "rocm[libraries,devel,device-all]"
+# For a specific GPU family instead, e.g.:
+# "rocm[libraries,devel,device-gfx942]"
 ```
 
-Replace `device-gfx942` with the pip extra for your GPU. See the
+See the
 [multi-arch releases section of RELEASES.md](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-multi-arch-rocm-python-packages)
 for the device extras table and full install instructions.
 

--- a/README.md
+++ b/README.md
@@ -76,18 +76,27 @@ For more detailed instructions see TheRock's instructions on [installing release
 
 #### Installing from tarballs
 
-Prerelease tarballs can be downloaded from https://rocm.prereleases.amd.com/tarball/.
+Prerelease tarballs can be downloaded from
+https://rocm.prereleases.amd.com/tarball-multi-arch/.
 
-After downloading, simply extract the release tarball into place:
+After downloading, extract the release tarball into place:
 
 ```bash
 mkdir therock-tarball && cd therock-tarball
-# For example...
-wget https://rocm.prereleases.amd.com/tarball/therock-dist-linux-gfx1151-7.9.0rc1.tar.gz
+
+# Per-family (smaller, one GPU family):
+wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-gfx94X-dcgpu-7.14.0rc1.tar.gz
+
+# Or multiarch (all GPUs):
+# wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0rc1.tar.gz
 
 mkdir install
 tar -xf *.tar.gz -C install
 ```
+
+Pick the tarball that matches your GPU family and ROCm version from the index
+(e.g. `gfx1151`, `gfx950-dcgpu`). Use the `multiarch` tarball to install all
+supported GPU families at once.
 #### Installing from Native Linux Packages
 
 AMD provides prerelease ROCm packages for both Debian-based and RPM-based Linux distributions.
@@ -129,20 +138,20 @@ sudo apt update
 ###### Install ROCm
 
 ```bash
-# Installs the ROCm HIP runtime (version- and architecture-independent).
-sudo apt install amdrocm-runtime
+# Installs the full ROCm core SDK (version- and architecture-independent).
+sudo apt install amdrocm-core
 # For a specific ROCm version and GPU arch instead, e.g.:
 # sudo apt install amdrocm7.14-gfx942
 ```
 
 ---
 
-##### Installing Packages on RPM-Based Systems
+##### Installing Packages on RHEL-Based Systems
 
 ###### Add the ROCm Repository
 
 The example below uses the `rhel10` profile; change it to match your
-distribution (e.g. `rhel8`, `rhel9`, `sles15`).
+distribution (e.g. `rhel8`, `rhel9`).
 
 ```bash
 sudo tee /etc/yum.repos.d/rocm.repo << EOF
@@ -161,8 +170,34 @@ sudo dnf clean all
 ###### Install ROCm
 
 ```bash
-# Installs the ROCm HIP runtime (version- and architecture-independent).
-sudo dnf install amdrocm-runtime
+# Installs the full ROCm core SDK (version- and architecture-independent).
+sudo dnf install amdrocm-core
 # For a specific ROCm version and GPU arch instead, e.g.:
 # sudo dnf install amdrocm7.14-gfx942
+```
+
+---
+
+##### Installing Packages on SLES-Based Systems
+
+SLES uses `zypper` rather than `dnf`. The example below uses the `sles15`
+profile; change it to match your distribution (e.g. `sles16`).
+
+###### Add the ROCm Repository
+
+```bash
+sudo rpm --import https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
+sudo zypper addrepo --gpgcheck --refresh https://rocm.prereleases.amd.com/packages-multi-arch/sles15/x86_64/ rocm
+sudo zypper --gpg-auto-import-keys refresh
+```
+
+---
+
+###### Install ROCm
+
+```bash
+# Installs the full ROCm core SDK (version- and architecture-independent).
+sudo zypper install amdrocm-core
+# For a specific ROCm version and GPU arch instead, e.g.:
+# sudo zypper install amdrocm7.14-gfx942
 ```

--- a/README.md
+++ b/README.md
@@ -42,37 +42,31 @@ For general and more detailed information on releases, see [`RELEASES.md` in The
 
 #### Installing ROCm Python packages
 
-##### Multi-arch (unified index)
-
 Multi-arch releases use a single index URL for all GPU architectures. Select
-your GPU using pip extras:
+your GPU using pip `[device-*]` extras:
 
-```bash
-pip install --index-url https://rocm.prereleases.amd.com/whl-multi-arch/ --pre "rocm[devel,device-gfx942]"
+```
+https://rocm.prereleases.amd.com/whl-multi-arch/
 ```
 
-Replace `device-gfx942` with the extra for your GPU (e.g. `device-gfx1100`,
-`device-gfx1201`). See the
+| Product Name        | GFX Target | GFX Family   | Pip extra        | Release Index                                      |
+| --------------------| ---------- | ------------ | ---------------- | -------------------------------------------------- |
+| MI300A/MI300X       | gfx942     | gfx94X-dcgpu | `device-gfx942`  | https://rocm.prereleases.amd.com/whl-multi-arch/   |
+| MI350X/MI355X       | gfx950     | gfx950-dcgpu | `device-gfx950`  | https://rocm.prereleases.amd.com/whl-multi-arch/   |
+| AMD Strix Halo iGPU | gfx1151    | gfx1151      | `device-gfx1151` | https://rocm.prereleases.amd.com/whl-multi-arch/   |
+
+```bash
+pip install --index-url https://rocm.prereleases.amd.com/whl-multi-arch/ --pre \
+  "rocm[libraries,devel,device-gfx942]"
+```
+
+Replace `device-gfx942` with the pip extra for your GPU from the table above.
+See the
 [multi-arch releases section of RELEASES.md](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-multi-arch-rocm-python-packages)
 for the full device table.
 
-##### Per-family (GPU-family-specific index)
-
-Per-family releases use a separate index URL for each GPU family:
-
-| Product Name        | GFX Target | GFX Family   | Release Index                                      |
-| --------------------| ---------- | ------------ | -------------------------------------------------- |
-| MI300A/MI300X       | gfx942     | gfx94X-dcgpu | https://rocm.prereleases.amd.com/whl/gfx94X-dcgpu/ |
-| MI350X/MI355X       | gfx950     | gfx950-dcgpu | https://rocm.prereleases.amd.com/whl/gfx950-dcgpu/ |
-| AMD Strix Halo iGPU | gfx1151    | gfx1151      | https://rocm.prereleases.amd.com/whl/gfx1151/      |
-
-Install instructions:
-```bash
-python -m pip install --index-url ${Release_Index} "rocm[libraries,devel]"
-```
-
 For more detailed instructions see TheRock's instructions on [installing releases using pip
-](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-per-family-releases-using-pip).
+](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-multi-arch-rocm-python-packages).
 
 #### Installing from tarballs
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ mkdir therock-tarball && cd therock-tarball
 # Multiarch (all GPUs):
 wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0rc1.tar.gz
 
-# Per-family (smaller, one GPU family):
+# Per-family (one GPU family):
 # wget https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-gfx94X-dcgpu-7.14.0rc1.tar.gz
 
 mkdir install
@@ -119,7 +119,7 @@ sudo apt update
 ###### Install ROCm
 
 ```bash
-# Installs the full ROCm core SDK (version- and architecture-independent).
+# Installs the full ROCm core SDK.
 sudo apt install amdrocm-core
 # For a specific ROCm version and GPU arch instead, e.g.:
 # sudo apt install amdrocm7.14-gfx942
@@ -151,7 +151,7 @@ sudo dnf clean all
 ###### Install ROCm
 
 ```bash
-# Installs the full ROCm core SDK (version- and architecture-independent).
+# Installs the full ROCm core SDK.
 sudo dnf install amdrocm-core
 # For a specific ROCm version and GPU arch instead, e.g.:
 # sudo dnf install amdrocm7.14-gfx942

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ wget https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg -O - \
 
 ###### Add the ROCm Repository
 
-Replace `<os_profile>` with the appropriate distribution profile
-(e.g. `debian12`, `ubuntu2404`).
+The example below uses the `ubuntu2404` profile; change it to match your
+distribution (e.g. `debian12`, `ubuntu2204`).
 
 ```bash
 sudo tee /etc/apt/sources.list.d/rocm.list << EOF
-deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://rocm.prereleases.amd.com/packages-multi-arch/<os_profile> stable main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://rocm.prereleases.amd.com/packages-multi-arch/ubuntu2404 stable main
 EOF
 sudo apt update
 ```
@@ -129,7 +129,10 @@ sudo apt update
 ###### Install ROCm
 
 ```bash
-sudo apt install amdrocm7.14-gfx942 # Change the version (7.14) and gfx arch (gfx942) based on your release and machine.
+# Installs the ROCm HIP runtime (version- and architecture-independent).
+sudo apt install amdrocm-runtime
+# For a specific ROCm version and GPU arch instead, e.g.:
+# sudo apt install amdrocm7.14-gfx942
 ```
 
 ---
@@ -138,14 +141,14 @@ sudo apt install amdrocm7.14-gfx942 # Change the version (7.14) and gfx arch (gf
 
 ###### Add the ROCm Repository
 
-Replace `<os_profile>` with the appropriate distribution profile
-(e.g. `rhel8`, `sles16`).
+The example below uses the `rhel10` profile; change it to match your
+distribution (e.g. `rhel8`, `rhel9`, `sles15`).
 
 ```bash
 sudo tee /etc/yum.repos.d/rocm.repo << EOF
 [rocm]
 name=ROCm Prerelease Repository
-baseurl=https://rocm.prereleases.amd.com/packages-multi-arch/<os_profile>/x86_64/
+baseurl=https://rocm.prereleases.amd.com/packages-multi-arch/rhel10/x86_64/
 enabled=1
 gpgcheck=1
 gpgkey=https://rocm.prereleases.amd.com/packages/gpg/rocm.gpg
@@ -158,5 +161,8 @@ sudo dnf clean all
 ###### Install ROCm
 
 ```bash
-sudo dnf install amdrocm7.14-gfx942 # Change the version (7.14) and gfx arch (gfx942) based on your release and machine.
+# Installs the ROCm HIP runtime (version- and architecture-independent).
+sudo dnf install amdrocm-runtime
+# For a specific ROCm version and GPU arch instead, e.g.:
+# sudo dnf install amdrocm7.14-gfx942
 ```

--- a/README.md
+++ b/README.md
@@ -43,30 +43,16 @@ For general and more detailed information on releases, see [`RELEASES.md` in The
 #### Installing ROCm Python packages
 
 Multi-arch releases use a single index URL for all GPU architectures. Select
-your GPU using pip `[device-*]` extras:
-
-```
-https://rocm.prereleases.amd.com/whl-multi-arch/
-```
-
-| Product Name        | GFX Target | GFX Family   | Pip extra        | Release Index                                      |
-| --------------------| ---------- | ------------ | ---------------- | -------------------------------------------------- |
-| MI300A/MI300X       | gfx942     | gfx94X-dcgpu | `device-gfx942`  | https://rocm.prereleases.amd.com/whl-multi-arch/   |
-| MI350X/MI355X       | gfx950     | gfx950-dcgpu | `device-gfx950`  | https://rocm.prereleases.amd.com/whl-multi-arch/   |
-| AMD Strix Halo iGPU | gfx1151    | gfx1151      | `device-gfx1151` | https://rocm.prereleases.amd.com/whl-multi-arch/   |
+your GPU using a pip `[device-*]` extra:
 
 ```bash
 pip install --index-url https://rocm.prereleases.amd.com/whl-multi-arch/ --pre \
   "rocm[libraries,devel,device-gfx942]"
 ```
 
-Replace `device-gfx942` with the pip extra for your GPU from the table above.
-See the
+Replace `device-gfx942` with the pip extra for your GPU. See the
 [multi-arch releases section of RELEASES.md](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-multi-arch-rocm-python-packages)
-for the full device table.
-
-For more detailed instructions see TheRock's instructions on [installing releases using pip
-](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-multi-arch-rocm-python-packages).
+for the device extras table and full install instructions.
 
 #### Installing from tarballs
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ for the device extras table and full install instructions.
 #### Installing from tarballs
 
 Prerelease tarballs can be downloaded from
-https://rocm.prereleases.amd.com/tarball-multi-arch/.
+<https://rocm.prereleases.amd.com/tarball-multi-arch/>.
 
 After downloading, extract the release tarball into place:
 
@@ -109,7 +109,7 @@ distribution (e.g. `debian12`, `ubuntu2204`, `ubuntu2604`).
 
 ```bash
 sudo tee /etc/apt/sources.list.d/rocm.list << EOF
-deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://rocm.prereleases.amd.com/packages-multi-arch/ubuntu2404 stable main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://rocm.prereleases.amd.com/packages-multi-arch/ubuntu2404/ stable main
 EOF
 sudo apt update
 ```


### PR DESCRIPTION
Updates the rockrel prerelease install docs for multi-arch artifacts:

- **Native packages** — point apt/rpm repos at `packages-multi-arch/` with copy-paste `ubuntu2404` / `rhel10` examples (also note `ubuntu2604`, `sles15`, `sles16`); default install to `amdrocm-core` with arch-specific `amdrocm7.14-gfx942` shown as a commented alternative. GPG key URL stays on `packages/gpg/rocm.gpg` (`packages-multi-arch/gpg/` still 403s).
- **Pip** — switch to the unified `whl-multi-arch/` index with `[device-*]` extras; drop the redundant local GPU table and link to TheRock `RELEASES.md` instead.
- **Tarballs** — switch to `tarball-multi-arch/` with the `multiarch` bundle as the default example.

Verified 7.14.0rc0 native package installs in Ubuntu 24.04, RHEL 10 (AlmaLinux), and SLES 15 containers.