### PR TITLE
Add python_version input to jax release workflow

### DIFF
--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -34,6 +34,10 @@ on:
         description: "Repository to checkout. Defaults to ROCm/TheRock."
         type: string
         default: "ROCm/TheRock"
+      python_version:
+        description: "Single Python version to build (empty for full matrix)"
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -53,3 +57,4 @@ jobs:
       tar_url: ${{ inputs.tar_url }}
       repository: ${{ inputs.repository || 'ROCm/TheRock' }}
       ref: ${{ inputs.ref || '' }}
+      python_version: ${{ inputs.python_version }}


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/TheRock/issues/5634 and https://github.com/ROCm/TheRock/issues/6218.

This will be used by https://github.com/ROCm/TheRock/pull/6117 which applies what https://github.com/ROCm/TheRock/pull/5727 added for pytorch to jax: an optional `build_jax` toggle and the `python_version` input to build for a single version instead of all versions.

## Test Plan

Dev release in TheRock: https://github.com/ROCm/TheRock/actions/runs/28469583076

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
