### PR TITLE
ci: Disable PyTorch builds in ASAN release wrapper

### DIFF
--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -35,10 +35,6 @@ on:
         description: "Run full PyTorch tests after scheduled nightly Linux PyTorch wheel builds complete."
         type: boolean
         default: false
-      build_pytorch:
-        description: "Build PyTorch wheels"
-        type: boolean
-        default: true
       python_version:
         description: "Single Python version for wheel builds (empty for full matrix)"
         type: string
@@ -65,7 +61,7 @@ jobs:
       prerelease_version: ${{ inputs.prerelease_version || '' }}
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'all' }}
       run_full_pytorch_tests: ${{ inputs.run_full_pytorch_tests || github.event_name == 'schedule' }}
-      build_pytorch: ${{ inputs.build_pytorch == '' && true || inputs.build_pytorch }}
+      build_pytorch: false
       python_version: ${{ inputs.python_version || '' }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}


### PR DESCRIPTION
## Motivation

Backport for the 7.14 release branch. Remove the `build_pytorch` dispatch input and hardcode `build_pytorch: false` in the call to TheRock's ASAN release workflow.

## Technical Details

The previous default of true was incorrect for an ASAN workflow, and the boolean pass-through expression was unreliable. TheRock's ASAN workflow already enforces `build_pytorch: false` and `build_jax: false` internally, so this aligns the rockrel wrapper with that intent.

Progress on ROCM/TheRock#6477

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
