### PR TITLE
fix(ci): Add build_variant input to rockrel test_artifacts.yml

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -51,6 +51,10 @@ on:
         description: "Branch, tag, or SHA to checkout in TheRock."
         type: string
         default: ""
+      build_variant:
+        description: "Build variant (e.g., release, asan)."
+        type: string
+        default: "release"
 
 permissions:
   contents: read
@@ -76,3 +80,4 @@ jobs:
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      build_variant: ${{ inputs.build_variant }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -59,7 +59,7 @@ on:
 permissions:
   contents: read
 
-run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.test_runs_on }})
+run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.build_variant }}, ${{ inputs.test_runs_on }})
 
 jobs:
   test:


### PR DESCRIPTION
## Motivation

  `multi_arch_release_linux.yml` (in TheRock) dispatches `test_artifacts.yml` via
  `benc-uk/workflow-dispatch` with a `build_variant` input (added in ROCm/TheRock#6459).
  When running in the rockrel context, the dispatch targets rockrel's thin-wrapper
  `test_artifacts.yml`, which did not declare `build_variant` as a valid
  `workflow_dispatch` input — causing GitHub to reject the dispatch with:

  > Unexpected inputs provided: ["build_variant"]
  
  Fixes the ASAN nightly failure: https://github.com/ROCm/rockrel/actions/runs/29296019987/job/86996465312
  
  ## Changes
  
  - Add `build_variant` input declaration to `workflow_dispatch` inputs
  - Pass `build_variant` through to `ROCm/TheRock/.github/workflows/test_artifacts.yml@main`

## Test Plan
Manually triggered the test_artifacts.yml workflow https://github.com/ROCm/rockrel/actions/runs/29347489543
## Test Result

successfully triggered with new input build_varient value and
run name: **Test Artifacts (gfx94X-dcgpu, nightly, comprehensive, asan, linux-mi325-gpu-rocm-cpu-sandbox)**

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
