### PR TITLE
Remove multi_arch input from test_pytorch_wheels_full.yml

### DIFF
--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -45,9 +45,6 @@ on:
       tests_to_include:
         type: string
         default: ""
-      multi_arch:
-        type: boolean
-        default: true
       repository:
         description: "TheRock repository to checkout."
         type: string
@@ -77,6 +74,5 @@ jobs:
       pytorch_git_repo: ${{ inputs.pytorch_git_repo }}
       test_configs: ${{ inputs.test_configs }}
       tests_to_include: ${{ inputs.tests_to_include }}
-      multi_arch: ${{ inputs.multi_arch }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Motivation

This must be merged together with https://github.com/ROCm/TheRock/pull/6551 which removes the input from the original workflow in TheRock.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
