### PR TITLE
[Quartz] Add notify_quartz to release workflows

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -51,7 +51,8 @@ run-name: >-
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: multi_arch_release.yml
@@ -76,9 +77,9 @@ jobs:
       id-token: write
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [release]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: multi_arch_release.yml

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -54,6 +54,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: multi_arch_release.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -80,6 +81,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: multi_arch_release.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -50,6 +50,14 @@ run-name: >-
   | Windows: ${{ inputs.windows_amdgpu_families || 'all' }}
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release.yml@main
     secrets: inherit
@@ -65,3 +73,13 @@ jobs:
       contents: write
       actions: write
       id-token: write
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [release]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -62,7 +62,7 @@ jobs:
           run_phase: started
           reporting_workflow: multi_arch_release.yml
           workflow_inputs: ${{ toJSON(inputs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
@@ -95,5 +95,5 @@ jobs:
           reporting_workflow: multi_arch_release.yml
           workflow_inputs: ${{ toJSON(inputs) }}
           workflow_captured_outputs: ${{ toJSON(needs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -58,7 +58,9 @@ jobs:
       reporting_workflow: multi_arch_release.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release.yml@main
@@ -85,4 +87,6 @@ jobs:
       reporting_workflow: multi_arch_release.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -51,16 +51,19 @@ run-name: >-
 
 jobs:
   notify_quartz_start:
+    name: "Quartz - started - release (rockrel)"
     if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: multi_arch_release.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: started
+          reporting_workflow: multi_arch_release.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release.yml@main
@@ -79,14 +82,18 @@ jobs:
       id-token: write
 
   notify_quartz_completed:
+    name: "Quartz - completed - release (rockrel)"
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [release]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: multi_arch_release.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: completed
+          reporting_workflow: multi_arch_release.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          workflow_captured_outputs: ${{ toJSON(needs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: started
           reporting_workflow: multi_arch_release.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release.yml

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -57,6 +57,14 @@ run-name: >-
   | Linux: ${{ inputs.linux_amdgpu_families || 'all' }}
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_asan.yml@main
     secrets: inherit
@@ -73,3 +81,13 @@ jobs:
       contents: read
       actions: write
       id-token: write
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [release]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -61,6 +61,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: multi_arch_release_asan.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -88,6 +89,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: multi_arch_release_asan.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -58,7 +58,8 @@ run-name: >-
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: multi_arch_release_asan.yml
@@ -84,9 +85,9 @@ jobs:
       id-token: write
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [release]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: multi_arch_release_asan.yml

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -57,18 +57,6 @@ run-name: >-
   | Linux: ${{ inputs.linux_amdgpu_families || 'all' }}
 
 jobs:
-  notify_quartz_start:
-    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: multi_arch_release_asan.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
-
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_asan.yml@main
     secrets: inherit
@@ -85,16 +73,3 @@ jobs:
       contents: read
       actions: write
       id-token: write
-
-  notify_quartz_completed:
-    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    needs: [release]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: multi_arch_release_asan.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -65,7 +65,9 @@ jobs:
       reporting_workflow: multi_arch_release_asan.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_asan.yml@main
@@ -93,4 +95,6 @@ jobs:
       reporting_workflow: multi_arch_release_asan.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -46,6 +46,14 @@ permissions:
 run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ inputs.rocm_version }}, Multiarch)
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   build_jax_wheels:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
     secrets: inherit
@@ -58,3 +66,13 @@ jobs:
       repository: ${{ inputs.repository || 'ROCm/TheRock' }}
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [build_jax_wheels]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -47,7 +47,8 @@ run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ i
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: multi_arch_release_linux_jax_wheels.yml
@@ -69,9 +70,9 @@ jobs:
       python_version: ${{ inputs.python_version }}
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [build_jax_wheels]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: multi_arch_release_linux_jax_wheels.yml

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -50,6 +50,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: multi_arch_release_linux_jax_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -73,6 +74,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: multi_arch_release_linux_jax_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -43,16 +43,19 @@ run-name: Multi-Arch Release Linux JAX Wheels (${{ inputs.release_type }}, ${{ i
 
 jobs:
   notify_quartz_start:
+    name: "Quartz - started - release JAX wheels (rockrel)"
     if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: multi_arch_release_linux_jax_wheels.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: started
+          reporting_workflow: multi_arch_release_linux_jax_wheels.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   build_jax_wheels:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
@@ -67,14 +70,18 @@ jobs:
       python_version: ${{ inputs.python_version }}
 
   notify_quartz_completed:
+    name: "Quartz - completed - release JAX wheels (rockrel)"
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [build_jax_wheels]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: multi_arch_release_linux_jax_wheels.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: completed
+          reporting_workflow: multi_arch_release_linux_jax_wheels.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          workflow_captured_outputs: ${{ toJSON(needs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: started
           reporting_workflow: multi_arch_release_linux_jax_wheels.yml
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release_linux_jax_wheels.yml

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -54,7 +54,9 @@ jobs:
       reporting_workflow: multi_arch_release_linux_jax_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   build_jax_wheels:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
@@ -78,4 +80,6 @@ jobs:
       reporting_workflow: multi_arch_release_linux_jax_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -54,7 +54,7 @@ jobs:
           run_phase: started
           reporting_workflow: multi_arch_release_linux_jax_wheels.yml
           workflow_inputs: ${{ toJSON(inputs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   build_jax_wheels:
@@ -83,5 +83,5 @@ jobs:
           reporting_workflow: multi_arch_release_linux_jax_wheels.yml
           workflow_inputs: ${{ toJSON(inputs) }}
           workflow_captured_outputs: ${{ toJSON(needs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -54,6 +54,14 @@ permissions:
 run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@main
     with:
@@ -66,3 +74,13 @@ jobs:
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [release]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -58,6 +58,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -81,6 +82,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -55,7 +55,8 @@ run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
@@ -77,9 +78,9 @@ jobs:
       python_version: ${{ inputs.python_version }}
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [release]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -62,7 +62,9 @@ jobs:
       reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@main
@@ -86,4 +88,6 @@ jobs:
       reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: started
           reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
@@ -71,6 +71,7 @@ jobs:
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@main
+    secrets: inherit
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       rocm_version: ${{ inputs.rocm_version }}
@@ -90,7 +91,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -55,16 +55,19 @@ run-name: Multi-Arch Release Linux PyTorch Wheels (${{ inputs.amdgpu_families }}
 
 jobs:
   notify_quartz_start:
+    name: "Quartz - started - release PyTorch wheels (rockrel)"
     if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: started
+          reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@main
@@ -80,14 +83,18 @@ jobs:
       python_version: ${{ inputs.python_version }}
 
   notify_quartz_completed:
+    name: "Quartz - completed - release PyTorch wheels (rockrel)"
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [release]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: completed
+          reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          workflow_captured_outputs: ${{ toJSON(needs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -66,7 +66,7 @@ jobs:
           run_phase: started
           reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
           workflow_inputs: ${{ toJSON(inputs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
@@ -96,5 +96,5 @@ jobs:
           reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
           workflow_inputs: ${{ toJSON(inputs) }}
           workflow_captured_outputs: ${{ toJSON(needs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -53,6 +53,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -75,6 +76,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -50,7 +50,8 @@ run-name: Multi-Arch Release Windows PyTorch Wheels (${{ inputs.amdgpu_families 
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
@@ -71,9 +72,9 @@ jobs:
       python_version: ${{ inputs.python_version }}
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [release]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -49,6 +49,14 @@ permissions:
 run-name: Multi-Arch Release Windows PyTorch Wheels (${{ inputs.amdgpu_families }}, ${{ inputs.release_type }}, ${{ inputs.rocm_version }})
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml@main
     with:
@@ -60,3 +68,13 @@ jobs:
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [release]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: started
           reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
@@ -66,6 +66,7 @@ jobs:
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml@main
+    secrets: inherit
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       rocm_version: ${{ inputs.rocm_version }}
@@ -84,7 +85,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -57,7 +57,9 @@ jobs:
       reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml@main
@@ -80,4 +82,6 @@ jobs:
       reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -61,7 +61,7 @@ jobs:
           run_phase: started
           reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
           workflow_inputs: ${{ toJSON(inputs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
@@ -90,5 +90,5 @@ jobs:
           reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
           workflow_inputs: ${{ toJSON(inputs) }}
           workflow_captured_outputs: ${{ toJSON(needs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -50,16 +50,19 @@ run-name: Multi-Arch Release Windows PyTorch Wheels (${{ inputs.amdgpu_families 
 
 jobs:
   notify_quartz_start:
+    name: "Quartz - started - release PyTorch wheels (rockrel)"
     if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: started
+          reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
     uses: ROCm/TheRock/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml@main
@@ -74,14 +77,18 @@ jobs:
       python_version: ${{ inputs.python_version }}
 
   notify_quartz_completed:
+    name: "Quartz - completed - release PyTorch wheels (rockrel)"
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [release]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: completed
+          reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          workflow_captured_outputs: ${{ toJSON(needs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -62,6 +62,14 @@ permissions:
 run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type || 'ci' }}, ${{ inputs.test_type }}, ${{ inputs.build_variant }}, ${{ inputs.test_runs_on }})
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   test:
     uses: ROCm/TheRock/.github/workflows/test_artifacts.yml@main
     secrets: inherit
@@ -81,3 +89,13 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       build_variant: ${{ inputs.build_variant }}
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [test]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -66,6 +66,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: test_artifacts.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -96,6 +97,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: test_artifacts.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -63,7 +63,8 @@ run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: test_artifacts.yml
@@ -92,9 +93,9 @@ jobs:
       build_variant: ${{ inputs.build_variant }}
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [test]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: test_artifacts.yml

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -63,16 +63,19 @@ run-name: Test Artifacts (${{ inputs.amdgpu_families }}, ${{ inputs.release_type
 
 jobs:
   notify_quartz_start:
+    name: "Quartz - started - test ROCm artifacts (rockrel)"
     if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: test_artifacts.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: started
+          reporting_workflow: test_artifacts.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
     uses: ROCm/TheRock/.github/workflows/test_artifacts.yml@main
@@ -95,14 +98,18 @@ jobs:
       build_variant: ${{ inputs.build_variant }}
 
   notify_quartz_completed:
+    name: "Quartz - completed - test ROCm artifacts (rockrel)"
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [test]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: test_artifacts.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: completed
+          reporting_workflow: test_artifacts.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          workflow_captured_outputs: ${{ toJSON(needs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -70,7 +70,9 @@ jobs:
       reporting_workflow: test_artifacts.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
     uses: ROCm/TheRock/.github/workflows/test_artifacts.yml@main
@@ -101,4 +103,6 @@ jobs:
       reporting_workflow: test_artifacts.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -74,7 +74,7 @@ jobs:
           run_phase: started
           reporting_workflow: test_artifacts.yml
           workflow_inputs: ${{ toJSON(inputs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
@@ -111,5 +111,5 @@ jobs:
           reporting_workflow: test_artifacts.yml
           workflow_inputs: ${{ toJSON(inputs) }}
           workflow_captured_outputs: ${{ toJSON(needs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: started
           reporting_workflow: test_artifacts.yml
@@ -105,7 +105,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: completed
           reporting_workflow: test_artifacts.yml

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -54,6 +54,14 @@ permissions:
 run-name: Test Native Linux Packages Install (${{ inputs.os_profile }}, ${{ inputs.release_type }}, ${{ inputs.test_type || 'sanity' }})
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   test:
     uses: ROCm/TheRock/.github/workflows/test_native_linux_packages_install.yml@main
     secrets: inherit
@@ -67,3 +75,13 @@ jobs:
       test_type: ${{ inputs.test_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [test]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -58,6 +58,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: test_native_linux_packages_install.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -82,6 +83,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: test_native_linux_packages_install.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -55,7 +55,8 @@ run-name: Test Native Linux Packages Install (${{ inputs.os_profile }}, ${{ inpu
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: test_native_linux_packages_install.yml
@@ -78,9 +79,9 @@ jobs:
       ref: ${{ inputs.ref }}
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [test]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: test_native_linux_packages_install.yml

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -66,7 +66,7 @@ jobs:
           run_phase: started
           reporting_workflow: test_native_linux_packages_install.yml
           workflow_inputs: ${{ toJSON(inputs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
@@ -97,5 +97,5 @@ jobs:
           reporting_workflow: test_native_linux_packages_install.yml
           workflow_inputs: ${{ toJSON(inputs) }}
           workflow_captured_outputs: ${{ toJSON(needs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -55,16 +55,19 @@ run-name: Test Native Linux Packages Install (${{ inputs.os_profile }}, ${{ inpu
 
 jobs:
   notify_quartz_start:
+    name: "Quartz - started - test rpm/deb install (rockrel)"
     if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: test_native_linux_packages_install.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: started
+          reporting_workflow: test_native_linux_packages_install.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
     uses: ROCm/TheRock/.github/workflows/test_native_linux_packages_install.yml@main
@@ -81,14 +84,18 @@ jobs:
       ref: ${{ inputs.ref }}
 
   notify_quartz_completed:
+    name: "Quartz - completed - test rpm/deb install (rockrel)"
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [test]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: test_native_linux_packages_install.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: completed
+          reporting_workflow: test_native_linux_packages_install.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          workflow_captured_outputs: ${{ toJSON(needs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -62,7 +62,9 @@ jobs:
       reporting_workflow: test_native_linux_packages_install.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
     uses: ROCm/TheRock/.github/workflows/test_native_linux_packages_install.yml@main
@@ -87,4 +89,6 @@ jobs:
       reporting_workflow: test_native_linux_packages_install.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: started
           reporting_workflow: test_native_linux_packages_install.yml
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: completed
           reporting_workflow: test_native_linux_packages_install.yml

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -64,6 +64,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: started
+      reporting_workflow: test_pytorch_wheels_full.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit
@@ -91,6 +92,7 @@ jobs:
     uses: ./.github/workflows/notify_quartz.yml
     with:
       run_phase: completed
+      reporting_workflow: test_pytorch_wheels_full.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
     secrets: inherit

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -61,7 +61,8 @@ run-name: Test PyTorch Full (${{ inputs.amdgpu_family }}, ${{ inputs.torch_versi
 
 jobs:
   notify_quartz_start:
-    uses: ./.github/workflows/notify_quartz.yml
+    if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: started
       reporting_workflow: test_pytorch_wheels_full.yml
@@ -87,9 +88,9 @@ jobs:
       ref: ${{ inputs.ref }}
 
   notify_quartz_completed:
-    if: ${{ always() }}
+    if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [test]
-    uses: ./.github/workflows/notify_quartz.yml
+    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
     with:
       run_phase: completed
       reporting_workflow: test_pytorch_wheels_full.yml

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -60,6 +60,14 @@ permissions:
 run-name: Test PyTorch Full (${{ inputs.amdgpu_family }}, ${{ inputs.torch_version }}, ${{ inputs.test_runs_on }})
 
 jobs:
+  notify_quartz_start:
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: started
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit
+
   test:
     uses: ROCm/TheRock/.github/workflows/test_pytorch_wheels_full.yml@main
     secrets: inherit
@@ -76,3 +84,13 @@ jobs:
       tests_to_include: ${{ inputs.tests_to_include }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+
+  notify_quartz_completed:
+    if: ${{ always() }}
+    needs: [test]
+    uses: ./.github/workflows/notify_quartz.yml
+    with:
+      run_phase: completed
+      workflow_inputs: ${{ toJSON(inputs) }}
+      workflow_captured_outputs: ${{ toJSON(needs) }}
+    secrets: inherit

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -68,7 +68,9 @@ jobs:
       reporting_workflow: test_pytorch_wheels_full.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
     uses: ROCm/TheRock/.github/workflows/test_pytorch_wheels_full.yml@main
@@ -96,4 +98,6 @@ jobs:
       reporting_workflow: test_pytorch_wheels_full.yml
       workflow_inputs: ${{ toJSON(inputs) }}
       workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets: inherit
+    secrets:
+      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
+      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: started
           reporting_workflow: test_pytorch_wheels_full.yml
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
         with:
           run_phase: completed
           reporting_workflow: test_pytorch_wheels_full.yml

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -61,16 +61,19 @@ run-name: Test PyTorch Full (${{ inputs.amdgpu_family }}, ${{ inputs.torch_versi
 
 jobs:
   notify_quartz_start:
+    name: "Quartz - started - test PyTorch wheels (full suite)"
     if: ${{ vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: started
-      reporting_workflow: test_pytorch_wheels_full.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: started
+          reporting_workflow: test_pytorch_wheels_full.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
     uses: ROCm/TheRock/.github/workflows/test_pytorch_wheels_full.yml@main
@@ -90,14 +93,18 @@ jobs:
       ref: ${{ inputs.ref }}
 
   notify_quartz_completed:
+    name: "Quartz - completed - test PyTorch wheels (full suite)"
     if: ${{ always() && vars.NOTIFY_QUARTZ_ENABLED == 'true' }}
     needs: [test]
-    uses: ROCm/TheRock/.github/workflows/notify_quartz.yml@main
-    with:
-      run_phase: completed
-      reporting_workflow: test_pytorch_wheels_full.yml
-      workflow_inputs: ${{ toJSON(inputs) }}
-      workflow_captured_outputs: ${{ toJSON(needs) }}
-    secrets:
-      GH_APP_HAULY_ID: ${{ secrets.GH_APP_HAULY_ID }}
-      GH_APP_HAULY_PRIVATE_KEY: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@main
+        with:
+          run_phase: completed
+          reporting_workflow: test_pytorch_wheels_full.yml
+          workflow_inputs: ${{ toJSON(inputs) }}
+          workflow_captured_outputs: ${{ toJSON(needs) }}
+          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -72,7 +72,7 @@ jobs:
           run_phase: started
           reporting_workflow: test_pytorch_wheels_full.yml
           workflow_inputs: ${{ toJSON(inputs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
@@ -106,5 +106,5 @@ jobs:
           reporting_workflow: test_pytorch_wheels_full.yml
           workflow_inputs: ${{ toJSON(inputs) }}
           workflow_captured_outputs: ${{ toJSON(needs) }}
-          gh_app_id: ${{ secrets.GH_APP_HAULY_ID }}
+          gh_app_client_id: ${{ secrets.GH_APP_HAULY_CID }}
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}


### PR DESCRIPTION
Adds Quartz start/completed notifications to each release- and test-related workflow, so
Quartz is informed when a run begins and ends. Uses the `ROCm/Quartz/.github/actions/notify_quartz`
composite action, pinned to `notify_quartz/v1.1.0` (`b47e20b7539b407072a0c2249ab5e8d9983fac4e`),
and `continue-on-error: true` so a notification failure never fails the release. Captures workflow
inputs (and job outputs on completion); the workflow file name is passed manually via
`reporting_workflow`, since the GitHub API does not expose it.

Gated on a new repo variable `NOTIFY_QUARTZ_ENABLED` - Quartz runs only if it is `'true'`.
The action warns (does not fail) when the GH App credentials are absent, so forks and
credential-less environments are unaffected.

Prerequisite before merging:
- https://github.com/ROCm/Quartz/pull/53 must be merged

Issue:  https://github.com/ROCm/Quartz/issues/19
