### PR TITLE
fix(ci): Remove `tar_url` input from JAX wheels workflow

### DIFF
--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -22,10 +22,6 @@ on:
         description: "URL for pip --find-links to install ROCm packages for the JAX manylinux build."
         type: string
         default: ""
-      tar_url:
-        description: "URL to TheRock tarball used for the build."
-        type: string
-        required: true
       ref:
         description: "Branch, tag, or SHA to checkout."
         type: string
@@ -54,7 +50,6 @@ jobs:
       release_type: ${{ inputs.release_type }}
       rocm_version: ${{ inputs.rocm_version }}
       rocm_package_find_links_url: ${{ inputs.rocm_package_find_links_url }}
-      tar_url: ${{ inputs.tar_url }}
       repository: ${{ inputs.repository || 'ROCm/TheRock' }}
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}


### PR DESCRIPTION
## Motivation

 TheRock PR [#6708](https://github.com/ROCm/TheRock/pull/6708) removed the `tar_url` input from multi_arch_release_linux_jax_wheels.yml's workflow_call interface. This PR updates the corresponding rockrel caller workflow to stay in sync, removing `tar_url` from both the `workflow_dispatch` inputs and the with: block passed to the reusable TheRock workflow. 
Without this fix, the workflow fails validation with:
```
  Invalid input, tar_url is not defined in the referenced workflow.
```
  Changes:
  - Removed tar_url from workflow_dispatch inputs in .github/workflows/multi_arch_release_linux_jax_wheels.yml
  - Removed tar_url from the with: block passed to ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main

## Test Result

https://github.com/ROCm/rockrel/actions/runs/30530104428  - multi release build 
https://github.com/ROCm/rockrel/actions/runs/30552244613  - downstream jax run triggered successfully !!

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
