### PR TITLE
fix(ci): update gfx942 single-GPU runner label to ccs-csp

### DIFF
--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -18,7 +18,7 @@ on:
       test_runs_on:
         type: string
         required: true
-        default: "linux-gfx942-1gpu-ossci-rocm"
+        default: "linux-gfx942-1gpu-ccs-csp-ossci-rocm"
       test_runs_on_multi_gpu:
         type: string
         default: "linux-gfx942-8gpu-ossci-rocm"


### PR DESCRIPTION
## Summary

- Updates `test_runs_on` default from `linux-gfx942-1gpu-ossci-rocm` → `linux-gfx942-1gpu-ccs-csp-ossci-rocm`

`linux-gfx942-1gpu-ossci-rocm` was the Vultr cluster single-GPU label, removed as part of the Vultr decommission in ROCm/therock-ci-config#21. Without this fix, any manual dispatch of this workflow using the default label will queue indefinitely with no runner to pick it up.

`linux-gfx942-1gpu-ccs-csp-ossci-rocm` is the current `test-runs-on` default for gfx94x in therock-ci-config.

## Test plan

- [ ] Manually dispatch the workflow with the default `test_runs_on` value and confirm it is picked up by a runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)