### PR TITLE
ci: default PyTorch release wheels to sccache

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -25,6 +25,10 @@ on:
           - nightly
           - prerelease
         default: dev
+      # Default to sccache so release wheels benefit from the S3 compiler cache
+      # like CI does (TheRock defaults its release-wheel build to sccache since
+      # ROCm/TheRock#5471; this wrapper had drifted, still defaulting to none).
+      # Set "none" for a clean, cache-free build.
       cache_type:
         description: "Compiler cache type"
         type: choice
@@ -32,7 +36,7 @@ on:
           - none
           - sccache
           - ccache
-        default: none
+        default: sccache
       run_full_pytorch_tests:
         description: Run full PyTorch tests after scheduled nightly wheel builds complete.
         type: boolean

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -25,9 +25,6 @@ on:
           - nightly
           - prerelease
         default: dev
-      # Default to sccache so release wheels use the same S3 compiler cache as
-      # CI (TheRock's release-wheel build defaults to sccache since
-      # ROCm/TheRock#5471). Set "none" for a clean, cache-free build.
       cache_type:
         description: "Compiler cache type"
         type: choice

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -25,10 +25,9 @@ on:
           - nightly
           - prerelease
         default: dev
-      # Default to sccache so release wheels benefit from the S3 compiler cache
-      # like CI does (TheRock defaults its release-wheel build to sccache since
-      # ROCm/TheRock#5471; this wrapper had drifted, still defaulting to none).
-      # Set "none" for a clean, cache-free build.
+      # Default to sccache so release wheels use the same S3 compiler cache as
+      # CI (TheRock's release-wheel build defaults to sccache since
+      # ROCm/TheRock#5471). Set "none" for a clean, cache-free build.
       cache_type:
         description: "Compiler cache type"
         type: choice

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -25,9 +25,6 @@ on:
           - nightly
           - prerelease
         default: dev
-      # Default to sccache so release wheels use the same S3 compiler cache as
-      # CI (TheRock's release-wheel build defaults to sccache since
-      # ROCm/TheRock#5471). Set "none" for a clean, cache-free build.
       cache_type:
         description: "Compiler cache type"
         type: choice

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -25,10 +25,9 @@ on:
           - nightly
           - prerelease
         default: dev
-      # Default to sccache so release wheels benefit from the S3 compiler cache
-      # like CI does (TheRock defaults its release-wheel build to sccache since
-      # ROCm/TheRock#5471; this wrapper had drifted, still defaulting to none).
-      # Set "none" for a clean, cache-free build.
+      # Default to sccache so release wheels use the same S3 compiler cache as
+      # CI (TheRock's release-wheel build defaults to sccache since
+      # ROCm/TheRock#5471). Set "none" for a clean, cache-free build.
       cache_type:
         description: "Compiler cache type"
         type: choice

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -25,6 +25,10 @@ on:
           - nightly
           - prerelease
         default: dev
+      # Default to sccache so release wheels benefit from the S3 compiler cache
+      # like CI does (TheRock defaults its release-wheel build to sccache since
+      # ROCm/TheRock#5471; this wrapper had drifted, still defaulting to none).
+      # Set "none" for a clean, cache-free build.
       cache_type:
         description: "Compiler cache type"
         type: choice
@@ -32,7 +36,7 @@ on:
           - none
           - sccache
           - ccache
-        default: none
+        default: sccache
       ref:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow."
         type: string


### PR DESCRIPTION
## Summary
- Default `cache_type` to `sccache` (from `none`) in the Linux and Windows PyTorch release-wheel workflows, matching TheRock's release-wheel default.

## Why
- TheRock's release-wheel build defaults to `sccache` (since ROCm/TheRock#5471), and the S3 sccache buckets + OIDC roles for `dev` / `nightly` / `prerelease` are already provisioned for `ROCm/rockrel`. Enabling it here lets release wheels reuse that cache and speeds up builds.
- `none` stays available for a clean, cache-free build when preferred.

## Already provisioned (no infra changes needed)
- Roles `therock-{dev,nightly,prerelease}` (acct `324352301041`) trust `ROCm/rockrel`; buckets `therock-pytorch-sccache-<release_type>` exist; both wrappers already grant `id-token: write`.

## Notes
- The bucket starts cold and warms over the first few release runs.
- `workflow_dispatch`-only: applies to runs dispatched without an explicit `cache_type`.