### PR TITLE
[Quartz] Upgrade action from notify_quartz/v1.1.0 to notify_quartz/v1.1.1

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: started
           reporting_workflow: multi_arch_release.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release.yml

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: started
           reporting_workflow: multi_arch_release_linux_jax_wheels.yml
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release_linux_jax_wheels.yml

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: started
           reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release_linux_pytorch_wheels.yml

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: started
           reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: completed
           reporting_workflow: multi_arch_release_windows_pytorch_wheels.yml

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: started
           reporting_workflow: test_artifacts.yml
@@ -105,7 +105,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: completed
           reporting_workflow: test_artifacts.yml

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: started
           reporting_workflow: test_native_linux_packages_install.yml
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: completed
           reporting_workflow: test_native_linux_packages_install.yml

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: started
           reporting_workflow: test_pytorch_wheels_full.yml
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: ROCm/Quartz/.github/actions/notify_quartz@b47e20b7539b407072a0c2249ab5e8d9983fac4e # notify_quartz/v1.1.0
+      - uses: ROCm/Quartz/.github/actions/notify_quartz@f386a9756620938616af0b4d5d04b24ae6e0353f # notify_quartz/v1.1.1
         with:
           run_phase: completed
           reporting_workflow: test_pytorch_wheels_full.yml


### PR DESCRIPTION
No problems in rockrel, but fixes failed runs in TheRock where Linux containers that only have `python3` available and not `python`

Related: https://github.com/ROCm/Quartz/issues/19