### PR TITLE
[bkc] Pin to use `release/bkc/therock-10.1-20260811` workflows

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -66,7 +66,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       release_type: ${{ inputs.release_type || 'nightly' }}

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -58,7 +58,7 @@ run-name: >-
 
 jobs:
   release:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_asan.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_asan.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       release_type: ${{ inputs.release_type || 'nightly' }}

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -58,7 +58,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   build_jax_wheels:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_jax_wheels.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       test_amdgpu_family: ${{ inputs.test_amdgpu_family }}

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -70,7 +70,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -65,7 +65,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   release:
-    uses: ROCm/TheRock/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml@main
+    uses: ROCm/TheRock/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -78,7 +78,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
-    uses: ROCm/TheRock/.github/workflows/test_artifacts.yml@main
+    uses: ROCm/TheRock/.github/workflows/test_artifacts.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       artifact_group: ${{ inputs.artifact_group }}

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -70,7 +70,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
-    uses: ROCm/TheRock/.github/workflows/test_native_linux_packages_install.yml@main
+    uses: ROCm/TheRock/.github/workflows/test_native_linux_packages_install.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       package_install_url: ${{ inputs.package_install_url }}

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -76,7 +76,7 @@ jobs:
           gh_app_private_key: ${{ secrets.GH_APP_HAULY_PRIVATE_KEY }}
 
   test:
-    uses: ROCm/TheRock/.github/workflows/test_pytorch_wheels_full.yml@main
+    uses: ROCm/TheRock/.github/workflows/test_pytorch_wheels_full.yml@release/bkc/therock-10.1-20260811
     secrets: inherit
     with:
       amdgpu_family: ${{ inputs.amdgpu_family }}


### PR DESCRIPTION
This uses workflow code from https://github.com/ROCm/TheRock/tree/release/bkc/therock-10.1-20260811 on this new release branch.

* Progress on https://github.com/ROCm/rockrel/issues/88
* Similar to https://github.com/ROCm/rockrel/pull/80