### PR TITLE
feat(scripts): [Branching Tagging] Add GitHub permission check

### DIFF
--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -14,23 +14,19 @@ Authentication is done via SSH. Remotes are configured via
 `git remote set-url` (with `add` fallback).
 
 High-level workflow:
-1. Reuse (or populate) the cached TheRock clone; reclone only when the cache
-    is missing or corrupt (`--force-clone` deletes and reclones when the cache
-    directory exists but is not a valid git repo). Otherwise fetch/prune to
-    pick up new commits.
-2. Hard-reset to the requested commit and populate submodules via
-    `fetch_sources.py` when available (fallback to `git submodule update`).
-3. Build an execution plan from `.gitmodules` + `git submodule status`,
-    capturing repo URL, commit SHA, and working tree path for each component
-    plus TheRock itself. Repos listed in `--exclude-list` and repos outside
-    the ROCm GitHub org are filtered out.
-4. For each component:
-    a. Set up the SSH `rocm-github` remote.
-    b. Check if the release branch already exists on the remote; if so, skip
-       the repo entirely (recorded as skipped, not a failure).
-    c. Create (or reset) the branch at the recorded commit.
-    d. Push to `rocm-github` (skipped in dry-run mode).
-5. Log a summary of successful and failed repos.
+1. Verify GitHub push/admin permissions for all repos (via GitHub API, no
+   clone required).
+2. Reuse (or populate) the cached TheRock clone; reclone only when the cache
+   is missing or corrupt (`--force-clone` deletes and reclones).
+3. Hard-reset to the requested commit and populate submodules via
+   `fetch_sources.py` when available (fallback to `git submodule update`).
+4. Build an execution plan from `.gitmodules` + `git submodule status`.
+5. For each component:
+   a. Set up the SSH `rocm-github` remote.
+   b. Check if the release branch already exists on the remote; skip if so.
+   c. Create (or reset) the branch at the recorded commit.
+   d. Push to `rocm-github` (skipped in dry-run mode).
+6. Log a summary of successful, skipped, and failed repos.
 
 Dry-run mode (the default) logs every action without touching remotes;
 `--no-dry-run` enables actual pushes.
@@ -52,38 +48,29 @@ Options:
                          (default: /tmp/rock-branching-cache)
 """
 import argparse
-import base64
-import json
 import logging
 import re
-import shlex
-import shutil
 import subprocess
 import sys
-import tempfile
-import urllib.error
-import urllib.request
-from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
 
+from release_utils import (
+    RockBase,
+    RepoInfo,
+    check_permissions,
+    fetch_lightweight_plan,
+    get_gh_token,
+)
 
-@dataclass
-class RepoInfo:
-    """Information about a repository to branch."""
 
-    url: str
-    commit: str
-    path: Path
-
-
-class RockBranchingAutomation:
+class RockBranchingAutomation(RockBase):
     """Automates creation of release branches for TheRock and its ROCm submodules."""
 
+    _cache_dir_name = "rock-branching-cache"
+
     def __init__(self, cli_args: argparse.Namespace) -> None:
-        self.release_branch: str = cli_args.branch_name
-        self.dry_run: bool = cli_args.dry_run
-        self.commitid: str = cli_args.commitid
+        super().__init__(cli_args)
 
         if not re.fullmatch(r"[0-9a-f]{40}", self.commitid):
             raise SystemExit(
@@ -91,371 +78,19 @@ class RockBranchingAutomation:
                 f"SHA-1 hash, got: {self.commitid!r}"
             )
 
-        self.exclude_list: set[str] = set(cli_args.exclude_list or [])
-        self.force_clone: bool = cli_args.force_clone
-        self.cache_dir: Path | None = (
-            Path(cli_args.cache_dir) if cli_args.cache_dir else None
-        )
-        self.rock_url: str = "https://github.com/ROCm/TheRock.git"
-        self.cache_root: Path | None = None
-
-        self._logger = logging.getLogger("rock_branching")
-
         self.log("Authentication Mode: SSH")
         self.log(f"Dry run mode = {self.dry_run}")
         if self.exclude_list:
             self.log(f"Exclude list: {self.exclude_list}")
 
-    def log(self, msg: str) -> None:
-        """Log an info-level message."""
-        self._logger.info(msg)
-
-    def run_command(
-        self,
-        args: list[str | Path],
-        cwd: Path,
-        *,
-        input_data: bytes | None = None,
-        stream: bool = False,
-        timeout: int | None = None,
-    ) -> None:
-        """Execute a subprocess command, raising CalledProcessError on failure.
-
-        Args:
-            args:       Command and arguments to execute.
-            cwd:        Working directory for the command.
-            input_data: Optional bytes piped to stdin.
-            stream:     If True, print stdout/stderr line-by-line as it arrives
-                        (useful for long-running operations like clone/fetch).
-                        If False, buffer output and log after completion.
-            timeout:    Maximum seconds to wait before raising TimeoutExpired.
-        """
-        cmd = args if isinstance(args, list) else [args]
-        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
-        sys.stdout.flush()
-
-        if stream:
-            process = subprocess.Popen(
-                cmd,
-                cwd=str(cwd),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-            )
-
-            for line in process.stdout:
-                self.log(line.rstrip())
-
-            try:
-                ret = process.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait()
-                raise
-            if ret != 0:
-                raise subprocess.CalledProcessError(ret, cmd)
-
-            return
-
-        try:
-            result = subprocess.run(
-                cmd,
-                cwd=str(cwd),
-                shell=False,
-                input=input_data,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-                stdin=None if input_data else subprocess.DEVNULL,
-                text=False,
-                timeout=timeout,
-            )
-
-            if result.stdout:
-                self.log(
-                    result.stdout
-                    if isinstance(result.stdout, str)
-                    else result.stdout.decode(errors="ignore")
-                )
-            if result.stderr:
-                self.log(
-                    result.stderr
-                    if isinstance(result.stderr, str)
-                    else result.stderr.decode(errors="ignore")
-                )
-
-        except subprocess.CalledProcessError as exc:
-            self.log(
-                (exc.stdout or b"").decode(errors="ignore")
-                if isinstance(exc.stdout, bytes)
-                else (exc.stdout or "")
-            )
-            self.log(
-                (exc.stderr or b"").decode(errors="ignore")
-                if isinstance(exc.stderr, bytes)
-                else (exc.stderr or "")
-            )
-            raise
-
-    def run_command_output(
-        self, args: list[str | Path], cwd: Path, timeout: int | None = None
-    ) -> str:
-        """Run a command and return its stripped stdout as a string.
-
-        Raises CalledProcessError on non-zero exit.
-        Raises subprocess.TimeoutExpired when *timeout* seconds elapse.
-        """
-        cmd = args if isinstance(args, list) else [args]
-        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
-
-        result = subprocess.run(
-            cmd,
-            cwd=str(cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            check=True,
-            stdin=subprocess.DEVNULL,
-            timeout=timeout,
-        )
-        return result.stdout.strip()
-
-    def _setup_remote(self, url: str, repo_dir: Path) -> None:
-        """Add or update the rocm-github remote for a repo."""
-        remote_url = self.convert_to_ssh(url)
-        try:
-            self.run_command(
-                ["git", "remote", "set-url", "rocm-github", remote_url],
-                cwd=repo_dir,
-            )
-        except subprocess.CalledProcessError:
-            self.run_command(
-                ["git", "remote", "add", "rocm-github", remote_url],
-                cwd=repo_dir,
-            )
-
     def _remote_branch_exists(self, repo_dir: Path) -> bool:
-        """Return True if the release branch already exists on rocm-github.
-
-        Raises CalledProcessError if the remote check itself fails.
-        Raises subprocess.TimeoutExpired if the network call hangs (60 s).
-        """
+        """Return True if the release branch already exists on rocm-github."""
         output = self.run_command_output(
             ["git", "ls-remote", "--heads", "rocm-github", self.release_branch],
             cwd=repo_dir,
             timeout=60,
         )
         return bool(output)
-
-    def _get_gh_token(self) -> str:
-        """Retrieve the GitHub token from the active gh CLI session.
-
-        Requires ``gh auth login`` to have been run beforehand.
-        Raises SystemExit with a clear message if gh is missing or not logged in.
-        """
-        try:
-            result = subprocess.run(
-                ["gh", "auth", "token"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                check=True,
-            )
-            token = result.stdout.strip()
-        except FileNotFoundError:
-            raise SystemExit(
-                "ERROR: gh CLI not found. Install it from https://cli.github.com "
-                "and run: gh auth login"
-            )
-        except subprocess.CalledProcessError:
-            raise SystemExit(
-                "ERROR: Not authenticated with gh CLI. Run: gh auth login"
-            )
-        if not token:
-            raise SystemExit(
-                "ERROR: gh auth token returned an empty token. Run: gh auth login"
-            )
-        return token
-
-    def _fetch_lightweight_plan(self, token: str) -> dict[str, str]:
-        """Fetch .gitmodules from the GitHub API and return a repo-name → URL map.
-
-        Calls GET /repos/ROCm/TheRock/contents/.gitmodules?ref=<commitid> to
-        read the submodule list at the requested commit without cloning anything.
-        Also includes TheRock itself. Repos outside the ROCm org and repos in
-        the exclude list are filtered out — matching the logic in build_plan().
-
-        Returns dict[repo_name, url].
-        """
-        api_url = (
-            f"https://api.github.com/repos/ROCm/TheRock/contents/.gitmodules"
-            f"?ref={self.commitid}"
-        )
-        req = urllib.request.Request(
-            api_url,
-            headers={
-                "Authorization": f"token {token}",
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-        )
-        try:
-            with urllib.request.urlopen(req, timeout=15) as resp:
-                data = json.loads(resp.read())
-        except urllib.error.HTTPError as exc:
-            raise SystemExit(
-                f"ERROR: Failed to fetch .gitmodules from GitHub API "
-                f"(HTTP {exc.code}). Check that the commit {self.commitid!r} "
-                f"exists and the token has repo read access."
-            )
-        except urllib.error.URLError as exc:
-            raise SystemExit(
-                f"ERROR: Network error fetching .gitmodules: {exc.reason}"
-            )
-
-        # GitHub returns the file content as base64-encoded text.
-        raw = base64.b64decode(data["content"]).decode()
-
-        # Parse submodule entries: extract path and url for each [submodule] block.
-        repo_map: dict[str, str] = {}
-        current_path: str | None = None
-        current_url: str | None = None
-
-        for line in raw.splitlines():
-            line = line.strip()
-            if line.startswith("[submodule"):
-                # Flush the previous entry if both fields were found.
-                if current_path and current_url:
-                    repo_name = Path(current_path).name
-                    url_lower = current_url.lower()
-                    is_rocm = (
-                        "github.com/rocm/" in url_lower
-                        or "github.com:rocm/" in url_lower
-                    )
-                    if is_rocm and repo_name not in self.exclude_list:
-                        repo_map[repo_name] = current_url
-                current_path = None
-                current_url = None
-            elif "=" in line:
-                key, _, value = line.partition("=")
-                key = key.strip()
-                value = value.strip()
-                if key == "path":
-                    current_path = value
-                elif key == "url":
-                    current_url = value
-
-        # Flush the last entry.
-        if current_path and current_url:
-            repo_name = Path(current_path).name
-            url_lower = current_url.lower()
-            is_rocm = (
-                "github.com/rocm/" in url_lower
-                or "github.com:rocm/" in url_lower
-            )
-            if is_rocm and repo_name not in self.exclude_list:
-                repo_map[repo_name] = current_url
-
-        # Always include TheRock itself.
-        repo_map["TheRock"] = self.rock_url
-        return repo_map
-
-    def _check_permissions(self, token: str, repo_map: dict[str, str]) -> None:
-        """Check GitHub push/admin permissions for every repo in repo_map.
-
-        Uses the GitHub REST API (GET /repos/{owner}/{repo}) to inspect the
-        ``permissions`` field returned for the authenticated user. Both
-        ``push`` and ``admin`` access are accepted — either is sufficient to
-        create and push a branch.
-
-        All repos are checked before aborting so the caller sees the full
-        list of failures in a single run. Raises SystemExit if any repo
-        lacks the required access level.
-        """
-        self.log("=" * 60)
-        self.log("  GitHub Permission Check")
-        self.log(f"  Verifying push/admin access for {len(repo_map)} repo(s)")
-        self.log("=" * 60)
-
-        failed_repos: dict[str, str] = {}
-        for repo_name, url in repo_map.items():
-            # Parse owner/repo from the URL before hitting the API.
-            try:
-                owner, repo = self._extract_owner_repo(url)
-            except ValueError as exc:
-                failed_repos[repo_name] = f"URL parse error: {exc}"
-                continue
-
-            # GET /repos/{owner}/{repo} returns a `permissions` object that
-            # reflects exactly what the authenticated user can do on that repo.
-            api_url = f"https://api.github.com/repos/{owner}/{repo}"
-            req = urllib.request.Request(
-                api_url,
-                headers={
-                    "Authorization": f"token {token}",
-                    "Accept": "application/vnd.github+json",
-                    # Pin the API version for stable field names.
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
-            try:
-                with urllib.request.urlopen(req, timeout=15) as resp:
-                    data = json.loads(resp.read())
-            except urllib.error.HTTPError as exc:
-                # 403 — token valid but explicitly denied.
-                # 404 — GitHub hides private repos as 404 when the token has
-                #        no visibility; treat it the same as access denied.
-                if exc.code == 403:
-                    failed_repos[repo_name] = (
-                        f"HTTP 403 Forbidden — token lacks access to "
-                        f"{owner}/{repo}"
-                    )
-                elif exc.code == 404:
-                    failed_repos[repo_name] = (
-                        f"HTTP 404 — repo {owner}/{repo} not found "
-                        "(token may lack visibility)"
-                    )
-                else:
-                    failed_repos[repo_name] = (
-                        f"HTTP {exc.code} from GitHub API for {owner}/{repo}"
-                    )
-                continue
-            except urllib.error.URLError as exc:
-                failed_repos[repo_name] = (
-                    f"Network error checking {owner}/{repo}: {exc.reason}"
-                )
-                continue
-
-            # `push` is the minimum write access needed to create a branch.
-            # `admin` implies all permissions including push, so accept either.
-            perms = data.get("permissions", {})
-            has_access = perms.get("push", False) or perms.get("admin", False)
-            if has_access:
-                self.log(f"Permission check OK: {owner}/{repo}")
-            else:
-                failed_repos[repo_name] = (
-                    f"Insufficient permissions for {owner}/{repo}: "
-                    f"push={perms.get('push')}, admin={perms.get('admin')}"
-                )
-
-        # Always print the summary so the user sees the counts even on failure.
-        total = len(repo_map)
-        passed = total - len(failed_repos)
-        self.log("=" * 60)
-        self.log("  Permission Check Summary")
-        self.log(f"  Passed : {passed} / {total} repo(s)")
-        self.log(f"  Failed : {len(failed_repos)} / {total} repo(s)")
-        self.log("=" * 60)
-
-        if failed_repos:
-            lines = [
-                f"  {name}: {reason}" for name, reason in failed_repos.items()
-            ]
-            raise SystemExit(
-                f"ERROR: Permission check failed for {len(failed_repos)} "
-                f"repo(s). Aborting before any branches are created.\n"
-                + "\n".join(lines)
-            )
 
     def _create_branch(self, commit: str, repo_dir: Path) -> None:
         """Create (or reset) the release branch at the given commit."""
@@ -468,8 +103,7 @@ class RockBranchingAutomation:
         """Push the release branch to rocm-github, respecting dry-run mode."""
         if self.dry_run:
             self.log(
-                f"[DRY RUN] Skipping push of {self.release_branch} "
-                f"for {repo_name}"
+                f"[DRY RUN] Skipping push of {self.release_branch} for {repo_name}"
             )
         else:
             self.run_command(
@@ -479,14 +113,7 @@ class RockBranchingAutomation:
             )
 
     def execute_plan(self, plan: dict[str, RepoInfo]) -> None:
-        """Execute the branching plan for every repo in *plan*.
-
-        For each repo:
-        1. Set up the ``rocm-github`` remote with the SSH URL.
-        2. Guard against a pre-existing remote branch (recorded as skipped, not failed, if found).
-        3. Create (or reset) the release branch at the recorded commit SHA.
-        4. Push to ``rocm-github`` (skipped in dry-run mode).
-        """
+        """Create and push release branches for every repo in the plan."""
         successful_repos: dict[str, RepoInfo] = {}
         skipped_repos: dict[str, str] = {}
         failed_repos: dict[str, str] = {}
@@ -495,9 +122,7 @@ class RockBranchingAutomation:
             self.log(f"Processing {repo_name} at {info.path}")
 
             if not info.path.exists():
-                failed_repos[repo_name] = (
-                    f"Repo path does not exist: {info.path}"
-                )
+                failed_repos[repo_name] = f"Repo path does not exist: {info.path}"
                 continue
 
             try:
@@ -509,15 +134,12 @@ class RockBranchingAutomation:
             try:
                 branch_exists = self._remote_branch_exists(info.path)
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-                failed_repos[repo_name] = (
-                    f"Remote branch check failed: {exc}"
-                )
+                failed_repos[repo_name] = f"Remote branch check failed: {exc}"
                 continue
 
             if branch_exists:
                 msg = (
-                    f"Remote branch {self.release_branch} already exists "
-                    "on rocm-github"
+                    f"Remote branch {self.release_branch} already exists on rocm-github"
                 )
                 self.log(msg)
                 skipped_repos[repo_name] = msg
@@ -549,266 +171,11 @@ class RockBranchingAutomation:
         if failed_repos:
             self.log(f"Failed repos: {pformat(failed_repos)}")
 
-    def convert_to_ssh(self, url: str) -> str:
-        """Convert https://github.com/X/Y.git to git@github.com:X/Y.git."""
-        if url.startswith("https://github.com/"):
-            path = url.replace("https://github.com/", "")
-            return f"git@github.com:{path}"
-        return url
-
-    def _extract_owner_repo(self, url: str) -> tuple[str, str]:
-        """Extract (owner, repo) from a GitHub HTTPS or SSH URL.
-
-        Handles both URL forms that appear in .gitmodules:
-          https://github.com/ROCm/hip.git  →  ("ROCm", "hip")
-          git@github.com:ROCm/hip.git      →  ("ROCm", "hip")
-
-        The .git suffix is optional in both cases.
-        Raises ValueError for any URL that does not match either pattern.
-        """
-        # HTTPS form: https://github.com/OWNER/REPO[.git]
-        m = re.match(r"https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
-        if m:
-            return m.group(1), m.group(2)
-        # SSH form: git@github.com:OWNER/REPO[.git]
-        m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
-        if m:
-            return m.group(1), m.group(2)
-        raise ValueError(f"Cannot extract owner/repo from URL: {url!r}")
-
-    def get_submodule_url_map(self, repo_dir: Path) -> dict[str, str]:
-        """Return mapping of submodule working-tree paths to remote URLs."""
-        gitmodules_path = repo_dir / ".gitmodules"
-        if not gitmodules_path.exists():
-            return {}
-
-        try:
-            path_entries = self.run_command_output(
-                [
-                    "git",
-                    "config",
-                    "--file",
-                    str(gitmodules_path),
-                    "--get-regexp",
-                    r"submodule\..*\.path",
-                ],
-                cwd=repo_dir,
-            )
-        except subprocess.CalledProcessError:
-            return {}
-
-        url_map: dict[str, str] = {}
-        for line in path_entries.splitlines():
-            # Each line looks like:
-            #   "submodule.external/hipcc.path external/hipcc"
-            parts = line.strip().split(None, 1)
-            if len(parts) != 2:
-                continue
-            key, path_value = parts
-            section = key.rsplit(".", 1)[0]
-            try:
-                url = self.run_command_output(
-                    [
-                        "git",
-                        "config",
-                        "--file",
-                        str(gitmodules_path),
-                        "--get",
-                        f"{section}.url",
-                    ],
-                    cwd=repo_dir,
-                )
-            except subprocess.CalledProcessError:
-                self.log(f"No URL entry for {section}; skipping")
-                continue
-            url_map[path_value.strip()] = url
-
-        return url_map
-
-    def build_plan(self) -> dict[str, RepoInfo]:
-        """Build the branching execution plan.
-
-        1. Clone (or reuse cached clone of) TheRock.
-        2. Check out and hard-reset to ``self.commitid``.
-        3. Populate submodules via ``fetch_sources.py`` (or ``git submodule update``).
-        4. Read ``git submodule status`` and ``.gitmodules`` to collect each
-           submodule's commit SHA, remote URL, and local path.
-        5. Return a dict keyed by repo name, including TheRock itself.
-        """
-        cache_root = (
-            self.cache_dir
-            or Path(tempfile.gettempdir()) / "rock-branching-cache"
-        )
-        cache_root.mkdir(parents=True, exist_ok=True)
-        clone_dir = cache_root / "TheRock"
-        self.cache_root = cache_root
-
-        needs_clone = not clone_dir.exists()
-        if not needs_clone and not (clone_dir / ".git").exists():
-            if not self.force_clone:
-                raise RuntimeError(
-                    f"Cache directory {clone_dir} exists but is not a git "
-                    "repo. Use --force-clone to delete it and reclone."
-                )
-            self.log(
-                f"Cache directory {clone_dir} is not a git repo; "
-                "removing before reclone (--force-clone)"
-            )
-            shutil.rmtree(clone_dir)
-            needs_clone = True
-
-        if needs_clone:
-            self.log(
-                f"Cloning TheRock repo from {self.rock_url} into {clone_dir}"
-            )
-            self.run_command(
-                ["git", "clone", str(self.rock_url), str(clone_dir)],
-                cwd=cache_root,
-                stream=True,
-                timeout=600,
-            )
-        else:
-            self.log(f"Reusing existing TheRock repo at {clone_dir}")
-
-            try:
-                remote_url = self.run_command_output(
-                    ["git", "remote", "get-url", "origin"],
-                    cwd=clone_dir,
-                )
-                if "TheRock" not in remote_url:
-                    raise RuntimeError(
-                        f"Existing repo at {clone_dir} does not look like "
-                        f"TheRock (origin={remote_url})"
-                    )
-            except subprocess.CalledProcessError as exc:
-                raise RuntimeError(
-                    f"Failed to inspect existing repo at {clone_dir}: {exc}"
-                ) from exc
-
-            self.log("Fetching latest changes for existing TheRock clone...")
-            self.run_command(
-                [
-                    "git",
-                    "fetch",
-                    "origin",
-                    "--prune",
-                    "--recurse-submodules=on-demand",
-                ],
-                cwd=clone_dir,
-                stream=True,
-                timeout=600,
-            )
-
-        fetch_script = clone_dir / "build_tools" / "fetch_sources.py"
-        rock_commit = self.commitid
-
-        self.log(f"Checking out TheRock at commit {rock_commit}")
-        self.run_command(["git", "checkout", rock_commit], cwd=clone_dir)
-        self.run_command(
-            ["git", "reset", "--hard", rock_commit], cwd=clone_dir
-        )
-
-        if fetch_script.exists():
-            self.log(
-                "Updating submodules via fetch_sources.py "
-                "(jobs=10, no patches)..."
-            )
-            self.run_command(
-                [
-                    "python3",
-                    str(fetch_script),
-                    "--jobs",
-                    "10",
-                    "--no-apply-patches",
-                ],
-                cwd=clone_dir,
-                stream=True,
-            )
-        else:
-            self.log(
-                "fetch_sources.py not found; "
-                "falling back to git submodule update"
-            )
-            self.run_command(
-                ["git", "submodule", "update", "--init", "--recursive"],
-                cwd=clone_dir,
-                stream=True,
-            )
-
-        self.log("Reading submodule status...")
-        try:
-            status_output = self.run_command_output(
-                ["git", "submodule", "status"],
-                cwd=clone_dir,
-            )
-            lines = status_output.split("\n") if status_output else []
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(
-                f"Failed to read submodule status: {exc}"
-            ) from exc
-
-        url_map = self.get_submodule_url_map(clone_dir)
-
-        plan: dict[str, RepoInfo] = {}
-
-        # Each line from `git submodule status` looks like:
-        #   " <sha> <path> (<describe>)"  or  "-<sha> <path>" (not initialized)
-        for line in lines:
-            if not line:
-                continue
-
-            parts = line.split()
-            if len(parts) < 2:
-                continue
-            sha = parts[0].lstrip("-+")
-            path = parts[1]
-
-            repo_name = Path(path).name
-            repo_url = url_map.get(path)
-
-            if not repo_url:
-                self.log(
-                    f"No URL found for submodule {path} in .gitmodules"
-                )
-                continue
-
-            if repo_name in self.exclude_list:
-                self.log(f"Skipping {repo_name} (in exclude list)")
-                continue
-
-            url_lower = repo_url.lower()
-            if (
-                "github.com/rocm/" not in url_lower
-                and "github.com:rocm/" not in url_lower
-            ):
-                self.log(
-                    f"Skipping {repo_name} "
-                    f"(not a ROCm org repo: {repo_url})"
-                )
-                continue
-
-            plan[repo_name] = RepoInfo(
-                url=repo_url,
-                commit=sha,
-                path=clone_dir / path,
-            )
-
-        plan["TheRock"] = RepoInfo(
-            url=self.rock_url,
-            commit=rock_commit,
-            path=clone_dir,
-        )
-
-        return plan
-
     def run(self) -> None:
-        """Build the execution plan and execute it."""
-        # Fetch token and check permissions before the expensive clone step.
-        # _fetch_lightweight_plan reads .gitmodules directly from the GitHub
-        # API at the requested commit — no local clone required.
-        token = self._get_gh_token()
-        repo_map = self._fetch_lightweight_plan(token)
-        self._check_permissions(token, repo_map)
+        """Check permissions, build the plan, and execute it."""
+        token = get_gh_token()
+        repo_map = fetch_lightweight_plan(token, self.commitid, self.exclude_list)
+        check_permissions(token, repo_map, self._logger, action="branches")
 
         plan = self.build_plan()
         self.log(f"Execution plan:\n{pformat(plan)}")
@@ -816,21 +183,14 @@ class RockBranchingAutomation:
 
 
 def main(argv: list[str]) -> int:
-    """Parse arguments and run the branching automation."""
-    parser = argparse.ArgumentParser(
-        description="Rock Branching Automation Tool",
-    )
+    parser = argparse.ArgumentParser(description="Rock Branching Automation Tool")
     parser.add_argument(
-        "-B",
-        "--branch-name",
-        required=True,
+        "-B", "--branch-name", required=True,
         help="Name of the release branch to create",
     )
     parser.add_argument(
-        "-C",
-        "--commitid",
-        required=True,
-        help="Commit ID of TheRock to branch from",
+        "-C", "--commitid", required=True,
+        help="Commit SHA of TheRock to branch from",
     )
     parser.add_argument(
         "--dry-run",
@@ -839,29 +199,20 @@ def main(argv: list[str]) -> int:
         help="Log actions without pushing to remotes (default: enabled)",
     )
     parser.add_argument(
-        "--exclude-list",
-        nargs="*",
-        default=[],
-        help="List of submodule repo names to exclude from branching",
+        "--exclude-list", nargs="*", default=[],
+        help="Submodule repo names to exclude from branching",
     )
     parser.add_argument(
-        "--force-clone",
-        action="store_true",
-        default=False,
-        help="Delete and reclone if cache directory exists but is not a "
-        "valid git repo",
+        "--force-clone", action="store_true", default=False,
+        help="Delete and reclone if cache dir exists but is not a valid git repo",
     )
     parser.add_argument(
-        "--cache-dir",
-        default=None,
-        help="Directory to cache the TheRock clone "
-        "(default: /tmp/rock-branching-cache)",
+        "--cache-dir", default=None,
+        help="Directory to cache the TheRock clone (default: /tmp/rock-branching-cache)",
     )
     args = parser.parse_args(argv)
 
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     try:
         RockBranchingAutomation(args).run()

--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -52,6 +52,7 @@ Options:
                          (default: /tmp/rock-branching-cache)
 """
 import argparse
+import base64
 import json
 import logging
 import re
@@ -246,28 +247,12 @@ class RockBranchingAutomation:
         )
         return bool(output)
 
-    def _check_permissions(self, plan: dict[str, "RepoInfo"]) -> None:
-        """Check GitHub push/admin permissions for every repo in the plan.
+    def _get_gh_token(self) -> str:
+        """Retrieve the GitHub token from the active gh CLI session.
 
-        Uses the GitHub REST API (GET /repos/{owner}/{repo}) to inspect the
-        ``permissions`` field returned for the authenticated user. Both
-        ``push`` and ``admin`` access are accepted — either is sufficient to
-        create and push a branch.
-
-        Token is sourced exclusively from the active ``gh`` CLI session via
-        ``gh auth token``. Requires ``gh auth login`` to have been run beforehand.
-
-        All repos are checked before aborting so the caller sees the full
-        list of failures in a single run. Raises SystemExit if the token is
-        missing or any repo lacks the required access level.
+        Requires ``gh auth login`` to have been run beforehand.
+        Raises SystemExit with a clear message if gh is missing or not logged in.
         """
-        self.log("=" * 60)
-        self.log("  GitHub Permission Check")
-        self.log(f"  Verifying push/admin access for {len(plan)} repo(s)")
-        self.log("=" * 60)
-
-        # Retrieve the token from the active gh CLI session.
-        # Requires `gh auth login` to have been run beforehand.
         try:
             result = subprocess.run(
                 ["gh", "auth", "token"],
@@ -290,12 +275,113 @@ class RockBranchingAutomation:
             raise SystemExit(
                 "ERROR: gh auth token returned an empty token. Run: gh auth login"
             )
+        return token
+
+    def _fetch_lightweight_plan(self, token: str) -> dict[str, str]:
+        """Fetch .gitmodules from the GitHub API and return a repo-name → URL map.
+
+        Calls GET /repos/ROCm/TheRock/contents/.gitmodules?ref=<commitid> to
+        read the submodule list at the requested commit without cloning anything.
+        Also includes TheRock itself. Repos outside the ROCm org and repos in
+        the exclude list are filtered out — matching the logic in build_plan().
+
+        Returns dict[repo_name, url].
+        """
+        api_url = (
+            f"https://api.github.com/repos/ROCm/TheRock/contents/.gitmodules"
+            f"?ref={self.commitid}"
+        )
+        req = urllib.request.Request(
+            api_url,
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            raise SystemExit(
+                f"ERROR: Failed to fetch .gitmodules from GitHub API "
+                f"(HTTP {exc.code}). Check that the commit {self.commitid!r} "
+                f"exists and the token has repo read access."
+            )
+        except urllib.error.URLError as exc:
+            raise SystemExit(
+                f"ERROR: Network error fetching .gitmodules: {exc.reason}"
+            )
+
+        # GitHub returns the file content as base64-encoded text.
+        raw = base64.b64decode(data["content"]).decode()
+
+        # Parse submodule entries: extract path and url for each [submodule] block.
+        repo_map: dict[str, str] = {}
+        current_path: str | None = None
+        current_url: str | None = None
+
+        for line in raw.splitlines():
+            line = line.strip()
+            if line.startswith("[submodule"):
+                # Flush the previous entry if both fields were found.
+                if current_path and current_url:
+                    repo_name = Path(current_path).name
+                    url_lower = current_url.lower()
+                    is_rocm = (
+                        "github.com/rocm/" in url_lower
+                        or "github.com:rocm/" in url_lower
+                    )
+                    if is_rocm and repo_name not in self.exclude_list:
+                        repo_map[repo_name] = current_url
+                current_path = None
+                current_url = None
+            elif "=" in line:
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip()
+                if key == "path":
+                    current_path = value
+                elif key == "url":
+                    current_url = value
+
+        # Flush the last entry.
+        if current_path and current_url:
+            repo_name = Path(current_path).name
+            url_lower = current_url.lower()
+            is_rocm = (
+                "github.com/rocm/" in url_lower
+                or "github.com:rocm/" in url_lower
+            )
+            if is_rocm and repo_name not in self.exclude_list:
+                repo_map[repo_name] = current_url
+
+        # Always include TheRock itself.
+        repo_map["TheRock"] = self.rock_url
+        return repo_map
+
+    def _check_permissions(self, token: str, repo_map: dict[str, str]) -> None:
+        """Check GitHub push/admin permissions for every repo in repo_map.
+
+        Uses the GitHub REST API (GET /repos/{owner}/{repo}) to inspect the
+        ``permissions`` field returned for the authenticated user. Both
+        ``push`` and ``admin`` access are accepted — either is sufficient to
+        create and push a branch.
+
+        All repos are checked before aborting so the caller sees the full
+        list of failures in a single run. Raises SystemExit if any repo
+        lacks the required access level.
+        """
+        self.log("=" * 60)
+        self.log("  GitHub Permission Check")
+        self.log(f"  Verifying push/admin access for {len(repo_map)} repo(s)")
+        self.log("=" * 60)
 
         failed_repos: dict[str, str] = {}
-        for repo_name, info in plan.items():
+        for repo_name, url in repo_map.items():
             # Parse owner/repo from the URL before hitting the API.
             try:
-                owner, repo = self._extract_owner_repo(info.url)
+                owner, repo = self._extract_owner_repo(url)
             except ValueError as exc:
                 failed_repos[repo_name] = f"URL parse error: {exc}"
                 continue
@@ -353,11 +439,12 @@ class RockBranchingAutomation:
                 )
 
         # Always print the summary so the user sees the counts even on failure.
-        passed = len(plan) - len(failed_repos)
+        total = len(repo_map)
+        passed = total - len(failed_repos)
         self.log("=" * 60)
         self.log("  Permission Check Summary")
-        self.log(f"  Passed : {passed} / {len(plan)} repo(s)")
-        self.log(f"  Failed : {len(failed_repos)} / {len(plan)} repo(s)")
+        self.log(f"  Passed : {passed} / {total} repo(s)")
+        self.log(f"  Failed : {len(failed_repos)} / {total} repo(s)")
         self.log("=" * 60)
 
         if failed_repos:
@@ -716,9 +803,15 @@ class RockBranchingAutomation:
 
     def run(self) -> None:
         """Build the execution plan and execute it."""
+        # Fetch token and check permissions before the expensive clone step.
+        # _fetch_lightweight_plan reads .gitmodules directly from the GitHub
+        # API at the requested commit — no local clone required.
+        token = self._get_gh_token()
+        repo_map = self._fetch_lightweight_plan(token)
+        self._check_permissions(token, repo_map)
+
         plan = self.build_plan()
         self.log(f"Execution plan:\n{pformat(plan)}")
-        self._check_permissions(plan)
         self.execute_plan(plan)
 
 

--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -250,15 +250,26 @@ class RockBranchingAutomation:
     def _check_permissions(self, plan: dict[str, "RepoInfo"]) -> None:
         """Check GitHub push/admin permissions for every repo in the plan.
 
-        Reads GITHUB_TOKEN from the environment. Checks all repos before
-        aborting so the user sees the complete list of failures at once.
-        Raises SystemExit if the token is missing or any repo lacks access.
+        Uses the GitHub REST API (GET /repos/{owner}/{repo}) to inspect the
+        ``permissions`` field returned for the authenticated user. Both
+        ``push`` and ``admin`` access are accepted — either is sufficient to
+        create and push a branch.
+
+        Token resolution order:
+          1. GITHUB_TOKEN environment variable.
+          2. ``gh auth token`` (active gh CLI session).
+
+        All repos are checked before aborting so the caller sees the full
+        list of failures in a single run. Raises SystemExit if the token is
+        missing or any repo lacks the required access level.
         """
         self.log("=" * 60)
         self.log("  GitHub Permission Check")
         self.log(f"  Verifying push/admin access for {len(plan)} repo(s)")
         self.log("=" * 60)
 
+        # Prefer an explicit env var; fall back to the active gh CLI session
+        # so users who ran `gh auth login` don't need to export a token manually.
         token = os.environ.get("GITHUB_TOKEN")
         if not token:
             try:
@@ -271,6 +282,7 @@ class RockBranchingAutomation:
                 )
                 token = result.stdout.strip()
             except (subprocess.CalledProcessError, FileNotFoundError):
+                # gh not installed or not logged in — handled below.
                 pass
         if not token:
             raise SystemExit(
@@ -280,18 +292,22 @@ class RockBranchingAutomation:
 
         failed_repos: dict[str, str] = {}
         for repo_name, info in plan.items():
+            # Parse owner/repo from the URL before hitting the API.
             try:
                 owner, repo = self._extract_owner_repo(info.url)
             except ValueError as exc:
                 failed_repos[repo_name] = f"URL parse error: {exc}"
                 continue
 
+            # GET /repos/{owner}/{repo} returns a `permissions` object that
+            # reflects exactly what the authenticated user can do on that repo.
             api_url = f"https://api.github.com/repos/{owner}/{repo}"
             req = urllib.request.Request(
                 api_url,
                 headers={
                     "Authorization": f"token {token}",
                     "Accept": "application/vnd.github+json",
+                    # Pin the API version for stable field names.
                     "X-GitHub-Api-Version": "2022-11-28",
                 },
             )
@@ -299,6 +315,9 @@ class RockBranchingAutomation:
                 with urllib.request.urlopen(req, timeout=15) as resp:
                     data = json.loads(resp.read())
             except urllib.error.HTTPError as exc:
+                # 403 — token valid but explicitly denied.
+                # 404 — GitHub hides private repos as 404 when the token has
+                #        no visibility; treat it the same as access denied.
                 if exc.code == 403:
                     failed_repos[repo_name] = (
                         f"HTTP 403 Forbidden — token lacks access to "
@@ -320,6 +339,8 @@ class RockBranchingAutomation:
                 )
                 continue
 
+            # `push` is the minimum write access needed to create a branch.
+            # `admin` implies all permissions including push, so accept either.
             perms = data.get("permissions", {})
             has_access = perms.get("push", False) or perms.get("admin", False)
             if has_access:
@@ -330,6 +351,7 @@ class RockBranchingAutomation:
                     f"push={perms.get('push')}, admin={perms.get('admin')}"
                 )
 
+        # Always print the summary so the user sees the counts even on failure.
         passed = len(plan) - len(failed_repos)
         self.log("=" * 60)
         self.log("  Permission Check Summary")
@@ -447,10 +469,20 @@ class RockBranchingAutomation:
         return url
 
     def _extract_owner_repo(self, url: str) -> tuple[str, str]:
-        """Extract (owner, repo) from a GitHub HTTPS or SSH URL."""
+        """Extract (owner, repo) from a GitHub HTTPS or SSH URL.
+
+        Handles both URL forms that appear in .gitmodules:
+          https://github.com/ROCm/hip.git  →  ("ROCm", "hip")
+          git@github.com:ROCm/hip.git      →  ("ROCm", "hip")
+
+        The .git suffix is optional in both cases.
+        Raises ValueError for any URL that does not match either pattern.
+        """
+        # HTTPS form: https://github.com/OWNER/REPO[.git]
         m = re.match(r"https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
         if m:
             return m.group(1), m.group(2)
+        # SSH form: git@github.com:OWNER/REPO[.git]
         m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
         if m:
             return m.group(1), m.group(2)

--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -52,13 +52,17 @@ Options:
                          (default: /tmp/rock-branching-cache)
 """
 import argparse
+import json
 import logging
+import os
 import re
 import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
@@ -243,6 +247,106 @@ class RockBranchingAutomation:
         )
         return bool(output)
 
+    def _check_permissions(self, plan: dict[str, "RepoInfo"]) -> None:
+        """Check GitHub push/admin permissions for every repo in the plan.
+
+        Reads GITHUB_TOKEN from the environment. Checks all repos before
+        aborting so the user sees the complete list of failures at once.
+        Raises SystemExit if the token is missing or any repo lacks access.
+        """
+        self.log("=" * 60)
+        self.log("  GitHub Permission Check")
+        self.log(f"  Verifying push/admin access for {len(plan)} repo(s)")
+        self.log("=" * 60)
+
+        token = os.environ.get("GITHUB_TOKEN")
+        if not token:
+            try:
+                result = subprocess.run(
+                    ["gh", "auth", "token"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    check=True,
+                )
+                token = result.stdout.strip()
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                pass
+        if not token:
+            raise SystemExit(
+                "ERROR: No GitHub token found. Either set GITHUB_TOKEN or "
+                "authenticate with: gh auth login"
+            )
+
+        failed_repos: dict[str, str] = {}
+        for repo_name, info in plan.items():
+            try:
+                owner, repo = self._extract_owner_repo(info.url)
+            except ValueError as exc:
+                failed_repos[repo_name] = f"URL parse error: {exc}"
+                continue
+
+            api_url = f"https://api.github.com/repos/{owner}/{repo}"
+            req = urllib.request.Request(
+                api_url,
+                headers={
+                    "Authorization": f"token {token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    data = json.loads(resp.read())
+            except urllib.error.HTTPError as exc:
+                if exc.code == 403:
+                    failed_repos[repo_name] = (
+                        f"HTTP 403 Forbidden — token lacks access to "
+                        f"{owner}/{repo}"
+                    )
+                elif exc.code == 404:
+                    failed_repos[repo_name] = (
+                        f"HTTP 404 — repo {owner}/{repo} not found "
+                        "(token may lack visibility)"
+                    )
+                else:
+                    failed_repos[repo_name] = (
+                        f"HTTP {exc.code} from GitHub API for {owner}/{repo}"
+                    )
+                continue
+            except urllib.error.URLError as exc:
+                failed_repos[repo_name] = (
+                    f"Network error checking {owner}/{repo}: {exc.reason}"
+                )
+                continue
+
+            perms = data.get("permissions", {})
+            has_access = perms.get("push", False) or perms.get("admin", False)
+            if has_access:
+                self.log(f"Permission check OK: {owner}/{repo}")
+            else:
+                failed_repos[repo_name] = (
+                    f"Insufficient permissions for {owner}/{repo}: "
+                    f"push={perms.get('push')}, admin={perms.get('admin')}"
+                )
+
+        passed = len(plan) - len(failed_repos)
+        self.log("=" * 60)
+        self.log("  Permission Check Summary")
+        self.log(f"  Passed : {passed} / {len(plan)} repo(s)")
+        self.log(f"  Failed : {len(failed_repos)} / {len(plan)} repo(s)")
+        self.log("=" * 60)
+
+        if failed_repos:
+            lines = [
+                f"  {name}: {reason}" for name, reason in failed_repos.items()
+            ]
+            raise SystemExit(
+                f"ERROR: Permission check failed for {len(failed_repos)} "
+                f"repo(s). Aborting before any branches are created.\n"
+                + "\n".join(lines)
+            )
+
     def _create_branch(self, commit: str, repo_dir: Path) -> None:
         """Create (or reset) the release branch at the given commit."""
         self.run_command(
@@ -341,6 +445,16 @@ class RockBranchingAutomation:
             path = url.replace("https://github.com/", "")
             return f"git@github.com:{path}"
         return url
+
+    def _extract_owner_repo(self, url: str) -> tuple[str, str]:
+        """Extract (owner, repo) from a GitHub HTTPS or SSH URL."""
+        m = re.match(r"https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1), m.group(2)
+        m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1), m.group(2)
+        raise ValueError(f"Cannot extract owner/repo from URL: {url!r}")
 
     def get_submodule_url_map(self, repo_dir: Path) -> dict[str, str]:
         """Return mapping of submodule working-tree paths to remote URLs."""
@@ -571,6 +685,7 @@ class RockBranchingAutomation:
         """Build the execution plan and execute it."""
         plan = self.build_plan()
         self.log(f"Execution plan:\n{pformat(plan)}")
+        self._check_permissions(plan)
         self.execute_plan(plan)
 
 

--- a/scripts/create_release_branch.py
+++ b/scripts/create_release_branch.py
@@ -54,7 +54,6 @@ Options:
 import argparse
 import json
 import logging
-import os
 import re
 import shlex
 import shutil
@@ -255,9 +254,8 @@ class RockBranchingAutomation:
         ``push`` and ``admin`` access are accepted — either is sufficient to
         create and push a branch.
 
-        Token resolution order:
-          1. GITHUB_TOKEN environment variable.
-          2. ``gh auth token`` (active gh CLI session).
+        Token is sourced exclusively from the active ``gh`` CLI session via
+        ``gh auth token``. Requires ``gh auth login`` to have been run beforehand.
 
         All repos are checked before aborting so the caller sees the full
         list of failures in a single run. Raises SystemExit if the token is
@@ -268,26 +266,29 @@ class RockBranchingAutomation:
         self.log(f"  Verifying push/admin access for {len(plan)} repo(s)")
         self.log("=" * 60)
 
-        # Prefer an explicit env var; fall back to the active gh CLI session
-        # so users who ran `gh auth login` don't need to export a token manually.
-        token = os.environ.get("GITHUB_TOKEN")
-        if not token:
-            try:
-                result = subprocess.run(
-                    ["gh", "auth", "token"],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    check=True,
-                )
-                token = result.stdout.strip()
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                # gh not installed or not logged in — handled below.
-                pass
+        # Retrieve the token from the active gh CLI session.
+        # Requires `gh auth login` to have been run beforehand.
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            token = result.stdout.strip()
+        except FileNotFoundError:
+            raise SystemExit(
+                "ERROR: gh CLI not found. Install it from https://cli.github.com "
+                "and run: gh auth login"
+            )
+        except subprocess.CalledProcessError:
+            raise SystemExit(
+                "ERROR: Not authenticated with gh CLI. Run: gh auth login"
+            )
         if not token:
             raise SystemExit(
-                "ERROR: No GitHub token found. Either set GITHUB_TOKEN or "
-                "authenticate with: gh auth login"
+                "ERROR: gh auth token returned an empty token. Run: gh auth login"
             )
 
         failed_repos: dict[str, str] = {}

--- a/scripts/release_utils.py
+++ b/scripts/release_utils.py
@@ -281,7 +281,14 @@ class RockBase:
         self.release_branch: str = cli_args.branch_name
         self.dry_run: bool = cli_args.dry_run
         self.commitid: str = cli_args.commitid
-        self.exclude_list: set[str] = set(cli_args.exclude_list or [])
+        # Accept both space-separated (--exclude-list a b c) and
+        # comma-separated (--exclude-list a,b,c) values.
+        self.exclude_list: set[str] = {
+            item.strip()
+            for val in (cli_args.exclude_list or [])
+            for item in val.split(",")
+            if item.strip()
+        }
         self.force_clone: bool = cli_args.force_clone
         self.cache_dir: Path | None = (
             Path(cli_args.cache_dir) if cli_args.cache_dir else None

--- a/scripts/release_utils.py
+++ b/scripts/release_utils.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""
+Shared utilities for ROCm release automation scripts.
+
+Provides:
+  - RepoInfo           dataclass describing a single repo in an execution plan
+  - RockBase           base class with subprocess helpers, git helpers, and
+                       build_plan() for cloning/reading TheRock submodules
+  - extract_owner_repo parse (owner, repo) from a GitHub HTTPS or SSH URL
+  - get_gh_token       retrieve the active gh CLI token
+  - fetch_lightweight_plan  read .gitmodules from the GitHub API (no clone)
+  - check_permissions  verify push/admin access for every repo in a plan
+"""
+import base64
+import json
+import logging
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from pprint import pformat
+
+
+ROCK_URL = "https://github.com/ROCm/TheRock.git"
+
+TIMEOUT_LONG = 1800   # clone, fetch, submodule update
+TIMEOUT_SHORT = 60    # tag, push, git config reads
+
+
+@dataclass
+class RepoInfo:
+    """A single repository entry in an execution plan."""
+
+    url: str
+    commit: str
+    path: Path
+
+
+# ---------------------------------------------------------------------------
+# Standalone GitHub helpers (no class state required)
+# ---------------------------------------------------------------------------
+
+def extract_owner_repo(url: str) -> tuple[str, str]:
+    """Return (owner, repo) from a GitHub HTTPS or SSH URL.
+
+    Accepts:
+      https://github.com/ROCm/hip.git  →  ("ROCm", "hip")
+      git@github.com:ROCm/hip.git      →  ("ROCm", "hip")
+
+    The .git suffix is optional. Raises ValueError for non-matching URLs.
+    """
+    m = re.match(r"https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1), m.group(2)
+    raise ValueError(f"Cannot extract owner/repo from URL: {url!r}")
+
+
+def get_gh_token() -> str:
+    """Return the GitHub token from the active gh CLI session.
+
+    Raises SystemExit with a clear message if gh is missing or not logged in.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        token = result.stdout.strip()
+    except FileNotFoundError:
+        raise SystemExit(
+            "ERROR: gh CLI not found. Install it from https://cli.github.com "
+            "and run: gh auth login"
+        )
+    except subprocess.CalledProcessError:
+        raise SystemExit(
+            "ERROR: Not authenticated with gh CLI. Run: gh auth login"
+        )
+    if not token:
+        raise SystemExit(
+            "ERROR: gh auth token returned an empty token. Run: gh auth login"
+        )
+    return token
+
+
+def fetch_lightweight_plan(
+    token: str,
+    commitid: str,
+    exclude_list: set[str],
+) -> dict[str, str]:
+    """Return a repo-name → URL map by reading .gitmodules from the GitHub API.
+
+    Fetches GET /repos/ROCm/TheRock/contents/.gitmodules?ref=<commitid> so the
+    caller can build a repo list without cloning anything locally. Filters out
+    repos outside the ROCm org and repos in exclude_list. Always includes
+    TheRock itself.
+    """
+    api_url = (
+        f"https://api.github.com/repos/ROCm/TheRock/contents/.gitmodules"
+        f"?ref={commitid}"
+    )
+    req = urllib.request.Request(
+        api_url,
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(
+            f"ERROR: Failed to fetch .gitmodules from GitHub API "
+            f"(HTTP {exc.code}). Check that commit {commitid!r} exists "
+            f"and the token has repo read access."
+        )
+    except urllib.error.URLError as exc:
+        raise SystemExit(
+            f"ERROR: Network error fetching .gitmodules: {exc.reason}"
+        )
+
+    raw = base64.b64decode(data["content"]).decode()
+
+    repo_map: dict[str, str] = {}
+    current_path: str | None = None
+    current_url: str | None = None
+
+    def _flush(path: str | None, url: str | None) -> None:
+        if not path or not url:
+            return
+        repo_name = Path(path).name
+        url_lower = url.lower()
+        is_rocm = (
+            "github.com/rocm/" in url_lower or "github.com:rocm/" in url_lower
+        )
+        if is_rocm and repo_name not in exclude_list:
+            repo_map[repo_name] = url
+
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("[submodule"):
+            _flush(current_path, current_url)
+            current_path = None
+            current_url = None
+        elif "=" in line:
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if key == "path":
+                current_path = value
+            elif key == "url":
+                current_url = value
+
+    _flush(current_path, current_url)
+
+    repo_map["TheRock"] = ROCK_URL
+    return repo_map
+
+
+def check_permissions(
+    token: str,
+    repo_map: dict[str, str],
+    logger: logging.Logger,
+    action: str = "branches",
+) -> None:
+    """Verify push/admin access for every repo in repo_map.
+
+    Checks GET /repos/{owner}/{repo} for each entry. Collects all failures
+    before raising so the caller sees the complete list in one run.
+    Raises SystemExit if any repo lacks the required access.
+
+    Args:
+        token:    GitHub personal access token.
+        repo_map: Mapping of repo name → GitHub URL.
+        logger:   Logger to use for progress output.
+        action:   Short noun used in the abort message ("branches" or "tags").
+    """
+    logger.info("=" * 60)
+    logger.info("  GitHub Permission Check")
+    logger.info("  Verifying push/admin access for %d repo(s)", len(repo_map))
+    logger.info("=" * 60)
+
+    failed: dict[str, str] = {}
+    for repo_name, url in repo_map.items():
+        try:
+            owner, repo = extract_owner_repo(url)
+        except ValueError as exc:
+            failed[repo_name] = f"URL parse error: {exc}"
+            continue
+
+        api_url = f"https://api.github.com/repos/{owner}/{repo}"
+        req = urllib.request.Request(
+            api_url,
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 403:
+                failed[repo_name] = (
+                    f"HTTP 403 Forbidden — token lacks access to "
+                    f"{owner}/{repo}"
+                )
+            elif exc.code == 404:
+                failed[repo_name] = (
+                    f"HTTP 404 — repo {owner}/{repo} not found "
+                    "(token may lack visibility)"
+                )
+            else:
+                failed[repo_name] = (
+                    f"HTTP {exc.code} from GitHub API for {owner}/{repo}"
+                )
+            continue
+        except urllib.error.URLError as exc:
+            failed[repo_name] = (
+                f"Network error checking {owner}/{repo}: {exc.reason}"
+            )
+            continue
+
+        perms = data.get("permissions", {})
+        if perms.get("push", False) or perms.get("admin", False):
+            logger.info("Permission check OK: %s/%s", owner, repo)
+        else:
+            failed[repo_name] = (
+                f"Insufficient permissions for {owner}/{repo}: "
+                f"push={perms.get('push')}, admin={perms.get('admin')}"
+            )
+
+    total = len(repo_map)
+    passed = total - len(failed)
+    logger.info("=" * 60)
+    logger.info("  Permission Check Summary")
+    logger.info("  Passed : %d / %d repo(s)", passed, total)
+    logger.info("  Failed : %d / %d repo(s)", len(failed), total)
+    logger.info("=" * 60)
+
+    if failed:
+        lines = [f"  {name}: {reason}" for name, reason in failed.items()]
+        raise SystemExit(
+            f"ERROR: Permission check failed for {len(failed)} repo(s). "
+            f"Aborting before any {action} are created.\n" + "\n".join(lines)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+class RockBase:
+    """Shared subprocess helpers, git helpers, and plan builder.
+
+    Subclasses set ``_cache_dir_name`` (used as the default cache directory
+    suffix under /tmp) and call ``super().__init__()`` after setting their
+    own attributes.
+    """
+
+    _cache_dir_name: str = "rock-cache"
+
+    def __init__(self, cli_args) -> None:
+        self.release_branch: str = cli_args.branch_name
+        self.dry_run: bool = cli_args.dry_run
+        self.commitid: str = cli_args.commitid
+        self.exclude_list: set[str] = set(cli_args.exclude_list or [])
+        self.force_clone: bool = cli_args.force_clone
+        self.cache_dir: Path | None = (
+            Path(cli_args.cache_dir) if cli_args.cache_dir else None
+        )
+        self.rock_url: str = ROCK_URL
+        self.cache_root: Path | None = None
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+    # ------------------------------------------------------------------
+    # Logging
+    # ------------------------------------------------------------------
+
+    def log(self, msg: str) -> None:
+        self._logger.info(msg)
+
+    # ------------------------------------------------------------------
+    # Subprocess helpers
+    # ------------------------------------------------------------------
+
+    def run_command(
+        self,
+        args: list[str | Path],
+        cwd: Path,
+        *,
+        input_data: bytes | None = None,
+        stream: bool = False,
+        timeout: int | None = None,
+    ) -> None:
+        """Execute a command, raising CalledProcessError on failure."""
+        cmd = args if isinstance(args, list) else [args]
+        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
+        sys.stdout.flush()
+
+        if stream:
+            process = subprocess.Popen(
+                cmd,
+                cwd=str(cwd),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            try:
+                for line in process.stdout:
+                    self.log(line.rstrip())
+                ret = process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+                raise subprocess.TimeoutExpired(cmd, timeout)
+            if ret != 0:
+                raise subprocess.CalledProcessError(ret, cmd)
+            return
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=str(cwd),
+                shell=False,
+                input=input_data,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+                stdin=None if input_data else subprocess.DEVNULL,
+                text=False,
+                timeout=timeout,
+            )
+            if result.stdout:
+                self.log(
+                    result.stdout
+                    if isinstance(result.stdout, str)
+                    else result.stdout.decode(errors="ignore")
+                )
+            if result.stderr:
+                self.log(
+                    result.stderr
+                    if isinstance(result.stderr, str)
+                    else result.stderr.decode(errors="ignore")
+                )
+        except subprocess.CalledProcessError as exc:
+            self.log(
+                (exc.stdout or b"").decode(errors="ignore")
+                if isinstance(exc.stdout, bytes)
+                else (exc.stdout or "")
+            )
+            self.log(
+                (exc.stderr or b"").decode(errors="ignore")
+                if isinstance(exc.stderr, bytes)
+                else (exc.stderr or "")
+            )
+            raise
+
+    def run_command_output(
+        self,
+        args: list[str | Path],
+        cwd: Path,
+        timeout: int | None = None,
+    ) -> str:
+        """Run a command and return its stripped stdout."""
+        cmd = args if isinstance(args, list) else [args]
+        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+        return result.stdout.strip()
+
+    # ------------------------------------------------------------------
+    # Git helpers
+    # ------------------------------------------------------------------
+
+    def convert_to_ssh(self, url: str) -> str:
+        """Convert https://github.com/X/Y.git to git@github.com:X/Y.git."""
+        if url.startswith("https://github.com/"):
+            return "git@github.com:" + url.replace("https://github.com/", "")
+        return url
+
+    def _setup_remote(self, url: str, repo_dir: Path) -> None:
+        """Add or update the rocm-github remote."""
+        remote_url = self.convert_to_ssh(url)
+        try:
+            self.run_command(
+                ["git", "remote", "set-url", "rocm-github", remote_url],
+                cwd=repo_dir,
+            )
+        except subprocess.CalledProcessError:
+            self.run_command(
+                ["git", "remote", "add", "rocm-github", remote_url],
+                cwd=repo_dir,
+            )
+
+    def get_submodule_url_map(self, repo_dir: Path) -> dict[str, str]:
+        """Return mapping of submodule working-tree paths to remote URLs."""
+        gitmodules_path = repo_dir / ".gitmodules"
+        if not gitmodules_path.exists():
+            return {}
+
+        try:
+            path_entries = self.run_command_output(
+                [
+                    "git", "config",
+                    "--file", str(gitmodules_path),
+                    "--get-regexp", r"submodule\..*\.path",
+                ],
+                cwd=repo_dir,
+            )
+        except subprocess.CalledProcessError:
+            return {}
+
+        url_map: dict[str, str] = {}
+        for line in path_entries.splitlines():
+            parts = line.strip().split(None, 1)
+            if len(parts) != 2:
+                continue
+            key, path_value = parts
+            section = key.rsplit(".", 1)[0]
+            try:
+                url = self.run_command_output(
+                    [
+                        "git", "config",
+                        "--file", str(gitmodules_path),
+                        "--get", f"{section}.url",
+                    ],
+                    cwd=repo_dir,
+                )
+            except subprocess.CalledProcessError:
+                self.log(f"No URL entry for {section}; skipping")
+                continue
+            url_map[path_value.strip()] = url
+
+        return url_map
+
+    # ------------------------------------------------------------------
+    # Plan builder
+    # ------------------------------------------------------------------
+
+    def _prepare_clone(self, cache_root: Path) -> Path:
+        """Ensure a valid TheRock clone exists under cache_root; return its path."""
+        clone_dir = cache_root / "TheRock"
+        needs_clone = not clone_dir.exists()
+
+        if not needs_clone and not (clone_dir / ".git").exists():
+            if not self.force_clone:
+                raise RuntimeError(
+                    f"Cache directory {clone_dir} exists but is not a git repo. "
+                    "Use --force-clone to delete it and reclone."
+                )
+            self.log(
+                f"Cache directory {clone_dir} is not a git repo; "
+                "removing before reclone (--force-clone)"
+            )
+            shutil.rmtree(clone_dir)
+            needs_clone = True
+
+        if needs_clone:
+            self.log(f"Cloning TheRock from {self.rock_url} into {clone_dir}")
+            self.run_command(
+                ["git", "clone", str(self.rock_url), str(clone_dir)],
+                cwd=cache_root,
+                stream=True,
+                timeout=TIMEOUT_LONG,
+            )
+        else:
+            self.log(f"Reusing existing TheRock repo at {clone_dir}")
+            try:
+                remote_url = self.run_command_output(
+                    ["git", "remote", "get-url", "origin"],
+                    cwd=clone_dir,
+                )
+                if "TheRock" not in remote_url:
+                    raise RuntimeError(
+                        f"Existing repo at {clone_dir} does not look like "
+                        f"TheRock (origin={remote_url})"
+                    )
+            except subprocess.CalledProcessError as exc:
+                raise RuntimeError(
+                    f"Failed to inspect existing repo at {clone_dir}: {exc}"
+                ) from exc
+
+            self.log("Fetching latest changes for existing TheRock clone...")
+            self.run_command(
+                ["git", "fetch", "origin", "--prune", "--recurse-submodules=on-demand"],
+                cwd=clone_dir,
+                stream=True,
+                timeout=TIMEOUT_LONG,
+            )
+
+        return clone_dir
+
+    def _checkout_and_update_submodules(self, clone_dir: Path) -> None:
+        """Hard-reset to self.commitid and populate submodules."""
+        rock_commit = self.commitid
+        self.log(f"Checking out TheRock at commit {rock_commit}")
+        self.run_command(["git", "checkout", rock_commit], cwd=clone_dir)
+        self.run_command(["git", "reset", "--hard", rock_commit], cwd=clone_dir)
+
+        fetch_script = clone_dir / "build_tools" / "fetch_sources.py"
+        if fetch_script.exists():
+            self.log("Updating submodules via fetch_sources.py (jobs=10, no patches)...")
+            self.run_command(
+                ["python3", str(fetch_script), "--jobs", "10", "--no-apply-patches"],
+                cwd=clone_dir,
+                stream=True,
+                timeout=TIMEOUT_LONG,
+            )
+        else:
+            self.log("fetch_sources.py not found; falling back to git submodule update")
+            self.run_command(
+                ["git", "submodule", "update", "--init", "--recursive"],
+                cwd=clone_dir,
+                stream=True,
+                timeout=TIMEOUT_LONG,
+            )
+
+    def build_plan(self) -> dict[str, RepoInfo]:
+        """Clone/reuse TheRock, populate submodules, and return the execution plan.
+
+        Subclasses may call super().build_plan() and extend the result, or
+        override _prepare_clone / _checkout_and_update_submodules for extra
+        git steps (e.g. fetching a release branch before checkout).
+        """
+        cache_root = (
+            self.cache_dir
+            or Path(tempfile.gettempdir()) / self._cache_dir_name
+        )
+        cache_root.mkdir(parents=True, exist_ok=True)
+        self.cache_root = cache_root
+
+        clone_dir = self._prepare_clone(cache_root)
+        self._checkout_and_update_submodules(clone_dir)
+
+        self.log("Reading submodule status...")
+        try:
+            status_output = self.run_command_output(
+                ["git", "submodule", "status"],
+                cwd=clone_dir,
+            )
+            lines = status_output.split("\n") if status_output else []
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Failed to read submodule status: {exc}") from exc
+
+        url_map = self.get_submodule_url_map(clone_dir)
+        plan: dict[str, RepoInfo] = {}
+
+        for line in lines:
+            if not line:
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            sha = parts[0].lstrip("-+")
+            path = parts[1]
+            repo_name = Path(path).name
+            repo_url = url_map.get(path)
+
+            if not repo_url:
+                self.log(f"No URL found for submodule {path} in .gitmodules")
+                continue
+            if repo_name in self.exclude_list:
+                self.log(f"Skipping {repo_name} (in exclude list)")
+                continue
+            url_lower = repo_url.lower()
+            if (
+                "github.com/rocm/" not in url_lower
+                and "github.com:rocm/" not in url_lower
+            ):
+                self.log(f"Skipping {repo_name} (not a ROCm org repo: {repo_url})")
+                continue
+
+            plan[repo_name] = RepoInfo(url=repo_url, commit=sha, path=clone_dir / path)
+
+        plan["TheRock"] = RepoInfo(
+            url=self.rock_url,
+            commit=self.commitid,
+            path=clone_dir,
+        )
+        return plan

--- a/scripts/release_utils.py
+++ b/scripts/release_utils.py
@@ -105,8 +105,8 @@ def fetch_lightweight_plan(
 
     Fetches GET /repos/ROCm/TheRock/contents/.gitmodules?ref=<commitid> so the
     caller can build a repo list without cloning anything locally. Filters out
-    repos outside the ROCm org and repos in exclude_list. Always includes
-    TheRock itself.
+    repos outside the ROCm org and repos in exclude_list. TheRock itself is
+    included unless it appears in exclude_list.
     """
     api_url = (
         f"https://api.github.com/repos/ROCm/TheRock/contents/.gitmodules"
@@ -168,7 +168,8 @@ def fetch_lightweight_plan(
 
     _flush(current_path, current_url)
 
-    repo_map["TheRock"] = ROCK_URL
+    if "TheRock" not in exclude_list:
+        repo_map["TheRock"] = ROCK_URL
     return repo_map
 
 
@@ -597,9 +598,12 @@ class RockBase:
 
             plan[repo_name] = RepoInfo(url=repo_url, commit=sha, path=clone_dir / path)
 
-        plan["TheRock"] = RepoInfo(
-            url=self.rock_url,
-            commit=self.commitid,
-            path=clone_dir,
-        )
+        if "TheRock" not in self.exclude_list:
+            plan["TheRock"] = RepoInfo(
+                url=self.rock_url,
+                commit=self.commitid,
+                path=clone_dir,
+            )
+        else:
+            self.log("Skipping TheRock (in exclude list)")
         return plan

--- a/scripts/rock_tagging.py
+++ b/scripts/rock_tagging.py
@@ -9,30 +9,28 @@ Automates tag and GitHub release creation for TheRock plus every tracked
 submodule. Authentication is done via SSH.
 
 High-level workflow:
-1. Reuse (or populate) a cached clone under a configurable directory
-    (default: `/tmp/rock-tagging-cache`, overridable via `--cache-dir`),
-    fetch the latest refs, and hard-reset to the user-specified commit.
-2. Update submodules via `fetch_sources.py` when available (fallback to
-    `git submodule update`) and build a plan by combining `.gitmodules`
-    metadata with `git submodule status` output. Repos listed in
-    `--exclude-list` and repos outside the ROCm GitHub org are skipped.
-3. For each component (inside a single loop):
-    a. Configure an SSH `rocm-github` remote.
-    b. Create an annotated tag (`therock-<version>`) at the recorded
-       commit, skipping components where the tag already exists.
-    c. For mono-repos (`rocm-libraries`, `rocm-systems`), generate
-       tarballs for the `projects/` and `shared/` directories (tarballs
-       are created even in dry-run mode).
-    d. When not in dry-run mode, push the tag and invoke
-       `gh release create` with the appropriate notes and tarball assets.
+1. Verify GitHub push/admin permissions for all repos (via GitHub API, no
+   clone required).
+2. Reuse (or populate) a cached clone under a configurable directory
+   (default: `/tmp/rock-tagging-cache`, overridable via `--cache-dir`),
+   fetch the latest refs, and hard-reset to the user-specified commit.
+3. Update submodules via `fetch_sources.py` when available (fallback to
+   `git submodule update`) and build a plan by combining `.gitmodules`
+   metadata with `git submodule status` output. Repos listed in
+   `--exclude-list` and repos outside the ROCm GitHub org are skipped.
+4. For each component:
+   a. Configure an SSH `rocm-github` remote.
+   b. Create an annotated tag (`therock-<version>`) at the recorded
+      commit, skipping components where the tag already exists.
+   c. For mono-repos (`rocm-libraries`, `rocm-systems`), generate
+      tarballs for the `projects/` and `shared/` directories.
+   d. When not in dry-run mode, push the tag and invoke
+      `gh release create` with the appropriate notes and tarball assets.
 
-Use `--force-clone` to delete and reclone when the cache directory exists
-but is not a valid git repo. All actions are logged for traceability, and
-dry-run mode (the default) lets you preview the plan without touching
-remotes.
+Dry-run mode (the default) lets you preview the plan without touching remotes.
 
 Usage:
-        python rock-tagging.py \\
+        python rock_tagging.py \\
                 --branch-name <release-branch> \\
                 --release-version <version> \\
                 --commitid <rock-commit-sha> \\
@@ -52,418 +50,57 @@ Options:
 """
 import argparse
 import logging
-import shlex
-import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
-from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
 
+from release_utils import (
+    RockBase,
+    RepoInfo,
+    TIMEOUT_LONG,
+    check_permissions,
+    fetch_lightweight_plan,
+    get_gh_token,
+)
 
-@dataclass
-class RepoInfo:
-    """Information about a repository to tag."""
 
-    url: str
-    commit: str
-    path: Path
-
-
-class RockTagging:
+class RockTagging(RockBase):
     """Automates tagging and release uploading for TheRock."""
+
+    _cache_dir_name = "rock-tagging-cache"
 
     MONO_REPOS = frozenset({"rocm-libraries", "rocm-systems"})
 
-    # Timeouts (seconds) for subprocess calls.
-    TIMEOUT_LONG = 1800   # clone, fetch, submodule update
-    TIMEOUT_SHORT = 60    # tag, push, git config reads
-
     def __init__(self, cli_args: argparse.Namespace) -> None:
-        self.release_branch: str = cli_args.branch_name
+        super().__init__(cli_args)
         self.release_version: str = cli_args.release_version
-        self.dry_run: bool = cli_args.dry_run
-        self.commitid: str = cli_args.commitid
-        self.exclude_list: set[str] = set(cli_args.exclude_list or [])
-        self.force_clone: bool = cli_args.force_clone
-        self.cache_dir: Path | None = (
-            Path(cli_args.cache_dir) if cli_args.cache_dir else None
-        )
-        self.rock_url: str = "https://github.com/ROCm/TheRock.git"
-        self.cache_root: Path | None = None
-
-        self._logger = logging.getLogger("rock_tagging")
 
         self.log("Authentication Mode: SSH")
         self.log(f"Dry run mode = {self.dry_run}")
         if self.exclude_list:
             self.log(f"Exclude list: {self.exclude_list}")
 
-    def log(self, msg: str) -> None:
-        """Log an info-level message."""
-        self._logger.info(msg)
-
-    def run_command(
-        self,
-        args: list[str | Path],
-        cwd: Path,
-        *,
-        input_data: bytes | None = None,
-        stream: bool = False,
-        timeout: int | None = TIMEOUT_SHORT,
-    ) -> None:
-        """Execute a subprocess command, raising CalledProcessError on failure.
-
-        Args:
-            args:       Command and arguments to execute.
-            cwd:        Working directory for the command.
-            input_data: Optional bytes piped to stdin.
-            stream:     If True, print stdout/stderr line-by-line as it arrives
-                        (useful for long-running operations like clone/fetch).
-                        If False, buffer output and log after completion.
-            timeout:    Seconds before the process is killed (default: TIMEOUT_SHORT).
-                        Pass TIMEOUT_LONG for clone/fetch/submodule operations.
-        """
-        cmd = args if isinstance(args, list) else [args]
-        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
-        sys.stdout.flush()
-
-        if stream:
-            process = subprocess.Popen(
-                cmd,
-                cwd=str(cwd),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-            )
-
-            try:
-                for line in process.stdout:
-                    self.log(line.rstrip())
-                ret = process.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait()
-                raise subprocess.TimeoutExpired(cmd, timeout)
-            if ret != 0:
-                raise subprocess.CalledProcessError(ret, cmd)
-
-            return
-
-        try:
-            result = subprocess.run(
-                cmd,
-                cwd=str(cwd),
-                shell=False,
-                input=input_data,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True,
-                stdin=None if input_data else subprocess.DEVNULL,
-                text=False,
-                timeout=timeout,
-            )
-
-            if result.stdout:
-                self.log(
-                    result.stdout
-                    if isinstance(result.stdout, str)
-                    else result.stdout.decode(errors="ignore")
-                )
-            if result.stderr:
-                self.log(
-                    result.stderr
-                    if isinstance(result.stderr, str)
-                    else result.stderr.decode(errors="ignore")
-                )
-
-        except subprocess.CalledProcessError as exc:
-            self.log(
-                (exc.stdout or b"").decode(errors="ignore")
-                if isinstance(exc.stdout, bytes)
-                else (exc.stdout or "")
-            )
-            self.log(
-                (exc.stderr or b"").decode(errors="ignore")
-                if isinstance(exc.stderr, bytes)
-                else (exc.stderr or "")
-            )
-            raise
-
-    def run_command_output(
-        self,
-        args: list[str | Path],
-        cwd: Path,
-        timeout: int | None = TIMEOUT_SHORT,
-    ) -> str:
-        """Run a command and return its stripped stdout as a string.
-
-        Raises CalledProcessError on non-zero exit.
-        """
-        cmd = args if isinstance(args, list) else [args]
-        self.log(f"++ Exec [{cwd}]$ {shlex.join(map(str, cmd))}")
-
-        result = subprocess.run(
-            cmd,
-            cwd=str(cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            check=True,
-            stdin=subprocess.DEVNULL,
-            timeout=timeout,
-        )
-        return result.stdout.strip()
-
-    def convert_to_ssh(self, url: str) -> str:
-        """Convert https://github.com/X/Y.git to git@github.com:X/Y.git."""
-        if url.startswith("https://github.com/"):
-            path = url.replace("https://github.com/", "")
-            return f"git@github.com:{path}"
-        return url
-
-    def get_submodule_url_map(self, repo_dir: Path) -> dict[str, str]:
-        """Return mapping of submodule working-tree paths to remote URLs."""
-        gitmodules_path = repo_dir / ".gitmodules"
-        if not gitmodules_path.exists():
-            return {}
-
-        try:
-            path_entries = self.run_command_output(
-                [
-                    "git",
-                    "config",
-                    "--file",
-                    str(gitmodules_path),
-                    "--get-regexp",
-                    r"submodule\..*\.path",
-                ],
-                cwd=repo_dir,
-            )
-        except subprocess.CalledProcessError:
-            return {}
-
-        url_map: dict[str, str] = {}
-        for line in path_entries.splitlines():
-            # Each line looks like:
-            #   "submodule.external/hipcc.path external/hipcc"
-            parts = line.strip().split(None, 1)
-            if len(parts) != 2:
-                continue
-            key, path_value = parts
-            section = key.rsplit(".", 1)[0]
-            try:
-                url = self.run_command_output(
-                    [
-                        "git",
-                        "config",
-                        "--file",
-                        str(gitmodules_path),
-                        "--get",
-                        f"{section}.url",
-                    ],
-                    cwd=repo_dir,
-                )
-            except subprocess.CalledProcessError:
-                self.log(f"No URL entry for {section}; skipping")
-                continue
-            url_map[path_value.strip()] = url
-
-        return url_map
-
-    def build_plan(self) -> dict[str, RepoInfo]:
-        """Build the tagging execution plan.
-
-        1. Clone (or reuse cached clone of) TheRock.
-        2. Check out and hard-reset to ``self.commitid``.
-        3. Populate submodules via ``fetch_sources.py`` (or ``git submodule update``).
-        4. Read ``git submodule status`` and ``.gitmodules`` to collect each
-           submodule's commit SHA, remote URL, and local path.
-        5. Return a dict keyed by repo name, including TheRock itself.
-        """
-        cache_root = (
-            self.cache_dir
-            or Path(tempfile.gettempdir()) / "rock-tagging-cache"
-        )
-        cache_root.mkdir(parents=True, exist_ok=True)
-        clone_dir = cache_root / "TheRock"
-        self.cache_root = cache_root
-
-        needs_clone = not clone_dir.exists()
-        if not needs_clone and not (clone_dir / ".git").exists():
-            if not self.force_clone:
-                raise RuntimeError(
-                    f"Cache directory {clone_dir} exists but is not a git "
-                    "repo. Use --force-clone to delete it and reclone."
-                )
-            self.log(
-                f"Cache directory {clone_dir} is not a git repo; "
-                "removing before reclone (--force-clone)"
-            )
-            shutil.rmtree(clone_dir)
-            needs_clone = True
-
-        if needs_clone:
-            self.log(
-                f"Cloning TheRock repo from {self.rock_url} into {clone_dir}"
-            )
-            self.run_command(
-                ["git", "clone", str(self.rock_url), str(clone_dir)],
-                cwd=cache_root,
-                stream=True,
-                timeout=self.TIMEOUT_LONG,
-            )
-        else:
-            self.log(f"Reusing existing TheRock repo at {clone_dir}")
-
-            try:
-                remote_url = self.run_command_output(
-                    ["git", "remote", "get-url", "origin"],
-                    cwd=clone_dir,
-                )
-                if "TheRock" not in remote_url:
-                    raise RuntimeError(
-                        f"Existing repo at {clone_dir} does not look like "
-                        f"TheRock (origin={remote_url})"
-                    )
-            except subprocess.CalledProcessError as exc:
-                raise RuntimeError(
-                    f"Failed to inspect existing repo at {clone_dir}: {exc}"
-                ) from exc
-
-            self.log("Fetching latest changes for existing TheRock clone...")
-            self.run_command(
-                [
-                    "git",
-                    "fetch",
-                    "origin",
-                    "--prune",
-                    "--recurse-submodules=on-demand",
-                ],
-                cwd=clone_dir,
-                stream=True,
-                timeout=self.TIMEOUT_LONG,
-            )
-
-        fetch_script = clone_dir / "build_tools" / "fetch_sources.py"
+    def _checkout_and_update_submodules(self, clone_dir: Path) -> None:
+        """Fetch the release branch then delegate to the base checkout logic."""
         rock_commit = self.commitid
-
         self.log(
             f"Fetching release branch '{self.release_branch}' to ensure "
             f"commit {rock_commit} is reachable..."
         )
         self.run_command(
             [
-                "git",
-                "fetch",
-                "origin",
-                f"refs/heads/{self.release_branch}:refs/remotes/origin/{self.release_branch}",
+                "git", "fetch", "origin",
+                f"refs/heads/{self.release_branch}:"
+                f"refs/remotes/origin/{self.release_branch}",
             ],
             cwd=clone_dir,
             stream=True,
-            timeout=self.TIMEOUT_LONG,
+            timeout=TIMEOUT_LONG,
         )
-
-        self.log(f"Checking out TheRock at commit {rock_commit}")
-        self.run_command(["git", "checkout", rock_commit], cwd=clone_dir)
-        self.run_command(
-            ["git", "reset", "--hard", rock_commit], cwd=clone_dir
-        )
-
-        if fetch_script.exists():
-            self.log(
-                "Updating submodules via fetch_sources.py "
-                "(jobs=10, no patches)..."
-            )
-            self.run_command(
-                [
-                    "python3",
-                    str(fetch_script),
-                    "--jobs",
-                    "10",
-                    "--no-apply-patches",
-                ],
-                cwd=clone_dir,
-                stream=True,
-                timeout=self.TIMEOUT_LONG,
-            )
-        else:
-            self.log(
-                "fetch_sources.py not found; "
-                "falling back to git submodule update"
-            )
-            self.run_command(
-                ["git", "submodule", "update", "--init", "--recursive"],
-                cwd=clone_dir,
-                stream=True,
-                timeout=self.TIMEOUT_LONG,
-            )
-
-        self.log("Reading submodule status...")
-        try:
-            status_output = self.run_command_output(
-                ["git", "submodule", "status"],
-                cwd=clone_dir,
-            )
-            lines = status_output.split("\n") if status_output else []
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(
-                f"Failed to read submodule status: {exc}"
-            ) from exc
-
-        url_map = self.get_submodule_url_map(clone_dir)
-
-        plan: dict[str, RepoInfo] = {}
-
-        for line in lines:
-            if not line:
-                continue
-
-            parts = line.split()
-            if len(parts) < 2:
-                continue
-            sha = parts[0].lstrip("-+")
-            path = parts[1]
-
-            repo_name = Path(path).name
-            repo_url = url_map.get(path)
-
-            if not repo_url:
-                self.log(
-                    f"No URL found for submodule {path} in .gitmodules"
-                )
-                continue
-
-            if repo_name in self.exclude_list:
-                self.log(f"Skipping {repo_name} (in exclude list)")
-                continue
-
-            url_lower = repo_url.lower()
-            if (
-                "github.com/rocm/" not in url_lower
-                and "github.com:rocm/" not in url_lower
-            ):
-                self.log(
-                    f"Skipping {repo_name} "
-                    f"(not a ROCm org repo: {repo_url})"
-                )
-                continue
-
-            plan[repo_name] = RepoInfo(
-                url=repo_url,
-                commit=sha,
-                path=clone_dir / path,
-            )
-
-        plan["TheRock"] = RepoInfo(
-            url=self.rock_url,
-            commit=rock_commit,
-            path=clone_dir,
-        )
-
-        return plan
+        super()._checkout_and_update_submodules(clone_dir)
 
     def _create_tarballs(
         self,
@@ -472,7 +109,7 @@ class RockTagging:
         tarball_paths: list[Path],
         label: str,
     ) -> None:
-        """Create per-subdirectory tarballs from *source_dir*."""
+        """Create per-subdirectory tarballs from source_dir."""
         if not source_dir.is_dir():
             self.log(f"Source directory not found for {label}: {source_dir}")
             return
@@ -481,39 +118,16 @@ class RockTagging:
         for entry in sorted(source_dir.iterdir()):
             if entry.name.startswith(".") or not entry.is_dir():
                 continue
-
             tarball_path = root_dir / f"{entry.name}.tar.gz"
             if tarball_path in tarball_paths:
                 continue
-
             with tarfile.open(tarball_path, "w:gz") as tf:
                 tf.add(str(entry), arcname=entry.name)
             tarball_paths.append(tarball_path)
             self.log(f"Tarball created: {tarball_path}")
 
-    def _setup_remote(self, url: str, repo_dir: Path) -> None:
-        """Add or update the rocm-github remote for a repo."""
-        remote_url = self.convert_to_ssh(url)
-        try:
-            self.run_command(
-                ["git", "remote", "set-url", "rocm-github", remote_url],
-                cwd=repo_dir,
-            )
-        except subprocess.CalledProcessError:
-            self.run_command(
-                ["git", "remote", "add", "rocm-github", remote_url],
-                cwd=repo_dir,
-            )
-
     def execute_plan(self, plan: dict[str, RepoInfo]) -> None:
-        """Execute the tagging plan for every repo in *plan*.
-
-        For each repo:
-        1. Configure the SSH ``rocm-github`` remote.
-        2. Create an annotated tag at the recorded commit.
-        3. For mono-repos, generate tarballs.
-        4. Push the tag and create a GitHub release (skipped in dry-run mode).
-        """
+        """Create and push tags, and publish GitHub releases, for every repo."""
         successful_components: dict[str, RepoInfo] = {}
         failed_components: dict[str, str] = {}
         work_dir = self.cache_root or Path(tempfile.gettempdir())
@@ -529,7 +143,6 @@ class RockTagging:
                 failed_components[comp] = f"Remote setup failed: {exc}"
                 continue
 
-            # Skip if tag already exists locally
             tag_exists = subprocess.run(
                 ["git", "rev-parse", "-q", "--verify", tag_name],
                 cwd=info.path,
@@ -538,41 +151,27 @@ class RockTagging:
             ).returncode == 0
 
             if tag_exists:
-                self.log(
-                    f"Tag {tag_name} already exists for {comp}; "
-                    "skipping creation"
-                )
+                self.log(f"Tag {tag_name} already exists for {comp}; skipping creation")
                 successful_components[comp] = info
                 continue
 
             try:
                 self.run_command(
                     [
-                        "git",
-                        "tag",
-                        "-a",
-                        tag_name,
-                        info.commit,
-                        "-m",
-                        f"therock release v{self.release_version}",
+                        "git", "tag", "-a", tag_name, info.commit,
+                        "-m", f"therock release v{self.release_version}",
                     ],
                     cwd=info.path,
                 )
                 if not self.dry_run:
                     self.run_command(
-                        [
-                            "git",
-                            "push",
-                            "rocm-github",
-                            f"{tag_name}:refs/tags/{tag_name}",
-                        ],
+                        ["git", "push", "rocm-github", f"{tag_name}:refs/tags/{tag_name}"],
                         cwd=info.path,
                     )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
                 failed_components[comp] = f"Tag failed: {exc}"
                 continue
 
-            # Tarballs only for mono-repos
             tarballs: list[Path] = []
             if comp in self.MONO_REPOS:
                 self._create_tarballs(
@@ -586,21 +185,18 @@ class RockTagging:
                 self.log(f"[DRY RUN] Would create release with: {tarballs}")
             else:
                 try:
-                    release_cmd = [
-                        "gh",
-                        "release",
-                        "create",
-                        tag_name,
-                        "--notes",
-                        f"therock release v{self.release_version}",
-                        *[str(p) for p in tarballs],
-                    ]
-                    self.run_command(release_cmd, cwd=info.path)
-                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-                    failed_components[comp] = (
-                        f"Release creation failed: {exc}"
+                    self.run_command(
+                        [
+                            "gh", "release", "create", tag_name,
+                            "--notes", f"therock release v{self.release_version}",
+                            *[str(p) for p in tarballs],
+                        ],
+                        cwd=info.path,
                     )
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+                    failed_components[comp] = f"Release creation failed: {exc}"
                     continue
+
             successful_components[comp] = info
 
         self.log(
@@ -613,34 +209,29 @@ class RockTagging:
             self.log(f"Failed components: {pformat(failed_components)}")
 
     def run(self) -> None:
-        """Build the execution plan and execute it."""
+        """Check permissions, build the plan, and execute it."""
+        token = get_gh_token()
+        repo_map = fetch_lightweight_plan(token, self.commitid, self.exclude_list)
+        check_permissions(token, repo_map, self._logger, action="tags")
+
         plan = self.build_plan()
         self.log(f"Execution plan: {pformat(plan)}")
         self.execute_plan(plan)
 
 
 def main(argv: list[str]) -> int:
-    """Parse arguments and run the tagging automation."""
-    parser = argparse.ArgumentParser(
-        description="Rock Tagging Automation Tool",
-    )
+    parser = argparse.ArgumentParser(description="Rock Tagging Automation Tool")
     parser.add_argument(
-        "-B",
-        "--branch-name",
-        required=True,
+        "-B", "--branch-name", required=True,
         help="Name of the release branch",
     )
     parser.add_argument(
-        "-V",
-        "--release-version",
-        required=True,
+        "-V", "--release-version", required=True,
         help="Release version string (used for tag names)",
     )
     parser.add_argument(
-        "-C",
-        "--commitid",
-        required=True,
-        help="Commit ID of TheRock to tag from",
+        "-C", "--commitid", required=True,
+        help="Commit SHA of TheRock to tag from",
     )
     parser.add_argument(
         "--dry-run",
@@ -649,29 +240,20 @@ def main(argv: list[str]) -> int:
         help="Log actions without pushing to remotes (default: enabled)",
     )
     parser.add_argument(
-        "--exclude-list",
-        nargs="*",
-        default=[],
-        help="List of submodule repo names to exclude from tagging",
+        "--exclude-list", nargs="*", default=[],
+        help="Submodule repo names to exclude from tagging",
     )
     parser.add_argument(
-        "--force-clone",
-        action="store_true",
-        default=False,
-        help="Delete and reclone if cache directory exists but is not a "
-        "valid git repo",
+        "--force-clone", action="store_true", default=False,
+        help="Delete and reclone if cache dir exists but is not a valid git repo",
     )
     parser.add_argument(
-        "--cache-dir",
-        default=None,
-        help="Directory to cache the TheRock clone "
-        "(default: /tmp/rock-tagging-cache)",
+        "--cache-dir", default=None,
+        help="Directory to cache the TheRock clone (default: /tmp/rock-tagging-cache)",
     )
     args = parser.parse_args(argv)
 
-    logging.basicConfig(
-        level=logging.INFO, format="[%(levelname)s] %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
     try:
         RockTagging(args).run()

--- a/scripts/tests/test_create_release_branch.py
+++ b/scripts/tests/test_create_release_branch.py
@@ -10,8 +10,11 @@ Covers:
 - get_submodule_url_map parsing
 - execute_plan behaviour with mocked subprocess calls
 """
+import json
 import subprocess
 import textwrap
+import urllib.error
+import urllib.request
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
@@ -233,6 +236,160 @@ class TestExecutePlan:
             if "push" in c.args[0]
         ]
         assert len(push_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# _extract_owner_repo
+# ---------------------------------------------------------------------------
+
+class TestExtractOwnerRepo:
+    @pytest.mark.parametrize("url,owner,repo", [
+        ("https://github.com/ROCm/hip.git",     "ROCm", "hip"),
+        ("https://github.com/ROCm/hip",         "ROCm", "hip"),
+        ("git@github.com:ROCm/hip.git",         "ROCm", "hip"),
+        ("git@github.com:ROCm/hip",             "ROCm", "hip"),
+        ("https://github.com/ROCm/TheRock.git", "ROCm", "TheRock"),
+    ])
+    def test_extraction(self, url, owner, repo):
+        auto = make_automation()
+        assert auto._extract_owner_repo(url) == (owner, repo)
+
+    def test_invalid_url_raises_value_error(self):
+        auto = make_automation()
+        with pytest.raises(ValueError):
+            auto._extract_owner_repo("not-a-url")
+
+
+# ---------------------------------------------------------------------------
+# _check_permissions
+# ---------------------------------------------------------------------------
+
+def _make_permission_plan(tmp_path: Path) -> dict[str, RepoInfo]:
+    return {
+        "hip": RepoInfo(
+            url="https://github.com/ROCm/hip.git",
+            commit="b" * 40,
+            path=tmp_path / "hip",
+        )
+    }
+
+
+def _make_mock_response(permissions: dict) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps({"permissions": permissions}).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestCheckPermissions:
+    def test_missing_token_raises(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        auto = make_automation()
+        plan = _make_permission_plan(tmp_path)
+        with pytest.raises(SystemExit) as exc_info:
+            auto._check_permissions(plan)
+        assert "GITHUB_TOKEN" in str(exc_info.value)
+
+    def test_insufficient_permission_raises_with_repo_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        auto = make_automation()
+        plan = _make_permission_plan(tmp_path)
+        mock_resp = _make_mock_response({"push": False, "admin": False})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(SystemExit) as exc_info:
+                auto._check_permissions(plan)
+        assert "hip" in str(exc_info.value)
+
+    def test_all_push_access_passes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        auto = make_automation()
+        plan = {
+            "hip": RepoInfo(
+                url="https://github.com/ROCm/hip.git",
+                commit="b" * 40,
+                path=tmp_path / "hip",
+            ),
+            "clr": RepoInfo(
+                url="https://github.com/ROCm/clr.git",
+                commit="c" * 40,
+                path=tmp_path / "clr",
+            ),
+        }
+        mock_resp = _make_mock_response({"push": True, "admin": False})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            auto._check_permissions(plan)  # must not raise
+
+    def test_admin_access_passes(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        auto = make_automation()
+        plan = _make_permission_plan(tmp_path)
+        mock_resp = _make_mock_response({"push": False, "admin": True})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            auto._check_permissions(plan)  # must not raise
+
+    def test_http_403_raises_with_repo_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        auto = make_automation()
+        plan = _make_permission_plan(tmp_path)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url=None, code=403, msg="Forbidden", hdrs=None, fp=None
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                auto._check_permissions(plan)
+        assert "hip" in str(exc_info.value)
+
+    def test_http_404_raises_with_repo_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        auto = make_automation()
+        plan = _make_permission_plan(tmp_path)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url=None, code=404, msg="Not Found", hdrs=None, fp=None
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                auto._check_permissions(plan)
+        assert "hip" in str(exc_info.value)
+
+    def test_multiple_failures_summary_lists_all(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        auto = make_automation()
+        plan = {
+            "hip": RepoInfo(
+                url="https://github.com/ROCm/hip.git",
+                commit="b" * 40,
+                path=tmp_path / "hip",
+            ),
+            "clr": RepoInfo(
+                url="https://github.com/ROCm/clr.git",
+                commit="c" * 40,
+                path=tmp_path / "clr",
+            ),
+        }
+        mock_resp = _make_mock_response({"push": False, "admin": False})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(SystemExit) as exc_info:
+                auto._check_permissions(plan)
+        msg = str(exc_info.value)
+        assert "hip" in msg
+        assert "clr" in msg
+
+    def test_network_error_recorded_as_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        auto = make_automation()
+        plan = _make_permission_plan(tmp_path)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                auto._check_permissions(plan)
+        assert "hip" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_create_release_branch.py
+++ b/scripts/tests/test_create_release_branch.py
@@ -23,7 +23,12 @@ import pytest
 
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-from scripts.create_release_branch import RepoInfo, RockBranchingAutomation
+from scripts.create_release_branch import RockBranchingAutomation
+from scripts.release_utils import (
+    RepoInfo,
+    check_permissions,
+    extract_owner_repo,
+)
 
 
 _FAKE_COMMIT = "a" * 40
@@ -251,28 +256,16 @@ class TestExtractOwnerRepo:
         ("https://github.com/ROCm/TheRock.git", "ROCm", "TheRock"),
     ])
     def test_extraction(self, url, owner, repo):
-        auto = make_automation()
-        assert auto._extract_owner_repo(url) == (owner, repo)
+        assert extract_owner_repo(url) == (owner, repo)
 
     def test_invalid_url_raises_value_error(self):
-        auto = make_automation()
         with pytest.raises(ValueError):
-            auto._extract_owner_repo("not-a-url")
+            extract_owner_repo("not-a-url")
 
 
 # ---------------------------------------------------------------------------
 # _check_permissions
 # ---------------------------------------------------------------------------
-
-def _make_permission_plan(tmp_path: Path) -> dict[str, RepoInfo]:
-    return {
-        "hip": RepoInfo(
-            url="https://github.com/ROCm/hip.git",
-            commit="b" * 40,
-            path=tmp_path / "hip",
-        )
-    }
-
 
 def _make_mock_response(permissions: dict) -> MagicMock:
     mock_resp = MagicMock()
@@ -282,56 +275,39 @@ def _make_mock_response(permissions: dict) -> MagicMock:
     return mock_resp
 
 
-class TestCheckPermissions:
-    def test_missing_token_raises(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        auto = make_automation()
-        plan = _make_permission_plan(tmp_path)
-        with pytest.raises(SystemExit) as exc_info:
-            auto._check_permissions(plan)
-        assert "GITHUB_TOKEN" in str(exc_info.value)
+def _repo_map() -> dict[str, str]:
+    return {"hip": "https://github.com/ROCm/hip.git"}
 
-    def test_insufficient_permission_raises_with_repo_name(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
-        auto = make_automation()
-        plan = _make_permission_plan(tmp_path)
+
+class TestCheckPermissions:
+    """check_permissions is now a standalone function in release_utils."""
+
+    def test_insufficient_permission_raises_with_repo_name(self):
         mock_resp = _make_mock_response({"push": False, "admin": False})
+        auto = make_automation()
         with patch("urllib.request.urlopen", return_value=mock_resp):
             with pytest.raises(SystemExit) as exc_info:
-                auto._check_permissions(plan)
+                check_permissions("fake-token", _repo_map(), auto._logger)
         assert "hip" in str(exc_info.value)
 
-    def test_all_push_access_passes(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
-        auto = make_automation()
-        plan = {
-            "hip": RepoInfo(
-                url="https://github.com/ROCm/hip.git",
-                commit="b" * 40,
-                path=tmp_path / "hip",
-            ),
-            "clr": RepoInfo(
-                url="https://github.com/ROCm/clr.git",
-                commit="c" * 40,
-                path=tmp_path / "clr",
-            ),
+    def test_all_push_access_passes(self):
+        repo_map = {
+            "hip": "https://github.com/ROCm/hip.git",
+            "clr": "https://github.com/ROCm/clr.git",
         }
         mock_resp = _make_mock_response({"push": True, "admin": False})
-        with patch("urllib.request.urlopen", return_value=mock_resp):
-            auto._check_permissions(plan)  # must not raise
-
-    def test_admin_access_passes(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
         auto = make_automation()
-        plan = _make_permission_plan(tmp_path)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            check_permissions("fake-token", repo_map, auto._logger)  # must not raise
+
+    def test_admin_access_passes(self):
         mock_resp = _make_mock_response({"push": False, "admin": True})
-        with patch("urllib.request.urlopen", return_value=mock_resp):
-            auto._check_permissions(plan)  # must not raise
-
-    def test_http_403_raises_with_repo_name(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
         auto = make_automation()
-        plan = _make_permission_plan(tmp_path)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            check_permissions("fake-token", _repo_map(), auto._logger)  # must not raise
+
+    def test_http_403_raises_with_repo_name(self):
+        auto = make_automation()
         with patch(
             "urllib.request.urlopen",
             side_effect=urllib.error.HTTPError(
@@ -339,13 +315,11 @@ class TestCheckPermissions:
             ),
         ):
             with pytest.raises(SystemExit) as exc_info:
-                auto._check_permissions(plan)
+                check_permissions("fake-token", _repo_map(), auto._logger)
         assert "hip" in str(exc_info.value)
 
-    def test_http_404_raises_with_repo_name(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    def test_http_404_raises_with_repo_name(self):
         auto = make_automation()
-        plan = _make_permission_plan(tmp_path)
         with patch(
             "urllib.request.urlopen",
             side_effect=urllib.error.HTTPError(
@@ -353,42 +327,31 @@ class TestCheckPermissions:
             ),
         ):
             with pytest.raises(SystemExit) as exc_info:
-                auto._check_permissions(plan)
+                check_permissions("fake-token", _repo_map(), auto._logger)
         assert "hip" in str(exc_info.value)
 
-    def test_multiple_failures_summary_lists_all(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
-        auto = make_automation()
-        plan = {
-            "hip": RepoInfo(
-                url="https://github.com/ROCm/hip.git",
-                commit="b" * 40,
-                path=tmp_path / "hip",
-            ),
-            "clr": RepoInfo(
-                url="https://github.com/ROCm/clr.git",
-                commit="c" * 40,
-                path=tmp_path / "clr",
-            ),
+    def test_multiple_failures_summary_lists_all(self):
+        repo_map = {
+            "hip": "https://github.com/ROCm/hip.git",
+            "clr": "https://github.com/ROCm/clr.git",
         }
         mock_resp = _make_mock_response({"push": False, "admin": False})
+        auto = make_automation()
         with patch("urllib.request.urlopen", return_value=mock_resp):
             with pytest.raises(SystemExit) as exc_info:
-                auto._check_permissions(plan)
+                check_permissions("fake-token", repo_map, auto._logger)
         msg = str(exc_info.value)
         assert "hip" in msg
         assert "clr" in msg
 
-    def test_network_error_recorded_as_failure(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    def test_network_error_recorded_as_failure(self):
         auto = make_automation()
-        plan = _make_permission_plan(tmp_path)
         with patch(
             "urllib.request.urlopen",
             side_effect=urllib.error.URLError("connection refused"),
         ):
             with pytest.raises(SystemExit) as exc_info:
-                auto._check_permissions(plan)
+                check_permissions("fake-token", _repo_map(), auto._logger)
         assert "hip" in str(exc_info.value)
 
 

--- a/scripts/tests/test_release_utils.py
+++ b/scripts/tests/test_release_utils.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""
+Tests for release_utils.py.
+
+Covers:
+- extract_owner_repo
+- get_gh_token
+- fetch_lightweight_plan
+- check_permissions
+- RockBase.convert_to_ssh
+- RockBase.get_submodule_url_map
+- RockBase.build_plan (clone / reuse / submodule parsing)
+"""
+import base64
+import json
+import subprocess
+import textwrap
+import urllib.error
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+from scripts.release_utils import (
+    RepoInfo,
+    RockBase,
+    check_permissions,
+    extract_owner_repo,
+    fetch_lightweight_plan,
+    get_gh_token,
+    ROCK_URL,
+    TIMEOUT_LONG,
+)
+
+
+_FAKE_COMMIT = "a" * 40
+
+
+def make_base(**kwargs) -> RockBase:
+    """Instantiate a bare RockBase (concrete enough for testing shared methods)."""
+    defaults = dict(
+        branch_name="release/6.4",
+        commitid=_FAKE_COMMIT,
+        dry_run=True,
+        exclude_list=[],
+        force_clone=False,
+        cache_dir=None,
+    )
+    defaults.update(kwargs)
+    return RockBase(SimpleNamespace(**defaults))
+
+
+def _make_mock_response(payload: dict) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(payload).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+# ---------------------------------------------------------------------------
+# extract_owner_repo
+# ---------------------------------------------------------------------------
+
+class TestExtractOwnerRepo:
+    @pytest.mark.parametrize("url,owner,repo", [
+        ("https://github.com/ROCm/hip.git",     "ROCm", "hip"),
+        ("https://github.com/ROCm/hip",         "ROCm", "hip"),
+        ("git@github.com:ROCm/hip.git",         "ROCm", "hip"),
+        ("git@github.com:ROCm/hip",             "ROCm", "hip"),
+        ("https://github.com/ROCm/TheRock.git", "ROCm", "TheRock"),
+        ("https://github.com/llvm/llvm-project.git", "llvm", "llvm-project"),
+    ])
+    def test_valid_urls(self, url, owner, repo):
+        assert extract_owner_repo(url) == (owner, repo)
+
+    def test_invalid_url_raises_value_error(self):
+        with pytest.raises(ValueError, match="Cannot extract owner/repo"):
+            extract_owner_repo("not-a-url")
+
+    def test_gitlab_url_raises_value_error(self):
+        with pytest.raises(ValueError):
+            extract_owner_repo("https://gitlab.com/ROCm/hip.git")
+
+    def test_bare_hostname_raises_value_error(self):
+        with pytest.raises(ValueError):
+            extract_owner_repo("https://github.com/ROCm")
+
+
+# ---------------------------------------------------------------------------
+# get_gh_token
+# ---------------------------------------------------------------------------
+
+class TestGetGhToken:
+    def test_returns_token_on_success(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "ghp_faketoken\n"
+        with patch("subprocess.run", return_value=mock_result):
+            token = get_gh_token()
+        assert token == "ghp_faketoken"
+
+    def test_gh_not_found_raises_system_exit(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(SystemExit, match="gh CLI not found"):
+                get_gh_token()
+
+    def test_not_authenticated_raises_system_exit(self):
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "gh"),
+        ):
+            with pytest.raises(SystemExit, match="Not authenticated"):
+                get_gh_token()
+
+    def test_empty_token_raises_system_exit(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "   "
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(SystemExit, match="empty token"):
+                get_gh_token()
+
+
+# ---------------------------------------------------------------------------
+# fetch_lightweight_plan
+# ---------------------------------------------------------------------------
+
+def _gitmodules_content(entries: list[tuple[str, str]]) -> str:
+    """Build a .gitmodules-style string from (path, url) pairs."""
+    blocks = []
+    for path, url in entries:
+        name = Path(path).name
+        blocks.append(
+            f'[submodule "{path}"]\n'
+            f"\tpath = {path}\n"
+            f"\turl = {url}\n"
+        )
+    return "\n".join(blocks)
+
+
+def _make_gitmodules_response(entries: list[tuple[str, str]]) -> MagicMock:
+    raw = _gitmodules_content(entries)
+    content_b64 = base64.b64encode(raw.encode()).decode()
+    return _make_mock_response({"content": content_b64})
+
+
+class TestFetchLightweightPlan:
+    def test_rocm_repos_included(self):
+        entries = [
+            ("external/hip", "https://github.com/ROCm/hip.git"),
+            ("external/clr", "https://github.com/ROCm/clr.git"),
+        ]
+        mock_resp = _make_gitmodules_response(entries)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = fetch_lightweight_plan("token", _FAKE_COMMIT, set())
+
+        assert "hip" in result
+        assert "clr" in result
+        assert result["hip"] == "https://github.com/ROCm/hip.git"
+
+    def test_therock_always_included(self):
+        mock_resp = _make_gitmodules_response([])
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = fetch_lightweight_plan("token", _FAKE_COMMIT, set())
+
+        assert "TheRock" in result
+        assert result["TheRock"] == ROCK_URL
+
+    def test_non_rocm_repos_excluded(self):
+        entries = [
+            ("external/llvm", "https://github.com/llvm/llvm-project.git"),
+            ("external/hip",  "https://github.com/ROCm/hip.git"),
+        ]
+        mock_resp = _make_gitmodules_response(entries)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = fetch_lightweight_plan("token", _FAKE_COMMIT, set())
+
+        assert "llvm-project" not in result
+        assert "hip" in result
+
+    def test_exclude_list_respected(self):
+        entries = [
+            ("external/hip", "https://github.com/ROCm/hip.git"),
+            ("external/clr", "https://github.com/ROCm/clr.git"),
+        ]
+        mock_resp = _make_gitmodules_response(entries)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = fetch_lightweight_plan("token", _FAKE_COMMIT, {"hip"})
+
+        assert "hip" not in result
+        assert "clr" in result
+
+    def test_http_error_raises_system_exit(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url=None, code=404, msg="Not Found", hdrs=None, fp=None
+            ),
+        ):
+            with pytest.raises(SystemExit, match="HTTP 404"):
+                fetch_lightweight_plan("token", _FAKE_COMMIT, set())
+
+    def test_network_error_raises_system_exit(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("name resolution failed"),
+        ):
+            with pytest.raises(SystemExit, match="Network error"):
+                fetch_lightweight_plan("token", _FAKE_COMMIT, set())
+
+    def test_ssh_urls_in_gitmodules_included(self):
+        entries = [
+            ("external/hip", "git@github.com:ROCm/hip.git"),
+        ]
+        mock_resp = _make_gitmodules_response(entries)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = fetch_lightweight_plan("token", _FAKE_COMMIT, set())
+
+        assert "hip" in result
+
+
+# ---------------------------------------------------------------------------
+# check_permissions
+# ---------------------------------------------------------------------------
+
+class TestCheckPermissions:
+    def _logger(self):
+        import logging
+        return logging.getLogger("test")
+
+    def test_push_access_passes(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        mock_resp = _make_mock_response({"permissions": {"push": True, "admin": False}})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            check_permissions("token", repo_map, self._logger())  # must not raise
+
+    def test_admin_access_passes(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        mock_resp = _make_mock_response({"permissions": {"push": False, "admin": True}})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            check_permissions("token", repo_map, self._logger())  # must not raise
+
+    def test_no_access_raises_system_exit(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        mock_resp = _make_mock_response({"permissions": {"push": False, "admin": False}})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(SystemExit) as exc_info:
+                check_permissions("token", repo_map, self._logger())
+        assert "hip" in str(exc_info.value)
+
+    def test_http_403_recorded_as_failure(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url=None, code=403, msg="Forbidden", hdrs=None, fp=None
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                check_permissions("token", repo_map, self._logger())
+        assert "hip" in str(exc_info.value)
+
+    def test_http_404_recorded_as_failure(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url=None, code=404, msg="Not Found", hdrs=None, fp=None
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                check_permissions("token", repo_map, self._logger())
+        assert "hip" in str(exc_info.value)
+
+    def test_other_http_error_recorded_as_failure(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(
+                url=None, code=500, msg="Server Error", hdrs=None, fp=None
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                check_permissions("token", repo_map, self._logger())
+        assert "hip" in str(exc_info.value)
+
+    def test_network_error_recorded_as_failure(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                check_permissions("token", repo_map, self._logger())
+        assert "hip" in str(exc_info.value)
+
+    def test_all_repos_checked_before_abort(self):
+        """All repos are checked even if the first one fails."""
+        repo_map = {
+            "hip": "https://github.com/ROCm/hip.git",
+            "clr": "https://github.com/ROCm/clr.git",
+        }
+        mock_resp = _make_mock_response({"permissions": {"push": False, "admin": False}})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(SystemExit) as exc_info:
+                check_permissions("token", repo_map, self._logger())
+        msg = str(exc_info.value)
+        assert "hip" in msg
+        assert "clr" in msg
+
+    def test_invalid_url_recorded_as_failure(self):
+        repo_map = {"bad": "not-a-url"}
+        with pytest.raises(SystemExit) as exc_info:
+            check_permissions("token", repo_map, self._logger())
+        assert "bad" in str(exc_info.value)
+
+    def test_action_label_appears_in_abort_message(self):
+        repo_map = {"hip": "https://github.com/ROCm/hip.git"}
+        mock_resp = _make_mock_response({"permissions": {"push": False, "admin": False}})
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(SystemExit) as exc_info:
+                check_permissions("token", repo_map, self._logger(), action="tags")
+        assert "tags" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# RockBase.convert_to_ssh
+# ---------------------------------------------------------------------------
+
+class TestConvertToSsh:
+    def test_https_converted(self):
+        base = make_base()
+        assert base.convert_to_ssh("https://github.com/ROCm/hip.git") == \
+            "git@github.com:ROCm/hip.git"
+
+    def test_https_without_dot_git(self):
+        base = make_base()
+        assert base.convert_to_ssh("https://github.com/ROCm/clr") == \
+            "git@github.com:ROCm/clr"
+
+    def test_ssh_passthrough(self):
+        base = make_base()
+        url = "git@github.com:ROCm/hip.git"
+        assert base.convert_to_ssh(url) == url
+
+    def test_non_github_passthrough(self):
+        base = make_base()
+        url = "https://gitlab.com/org/repo.git"
+        assert base.convert_to_ssh(url) == url
+
+
+# ---------------------------------------------------------------------------
+# RockBase.get_submodule_url_map
+# ---------------------------------------------------------------------------
+
+class TestGetSubmoduleUrlMap:
+    def test_no_gitmodules_returns_empty(self, tmp_path):
+        base = make_base()
+        assert base.get_submodule_url_map(tmp_path) == {}
+
+    def test_parses_paths_and_urls(self, tmp_path):
+        (tmp_path / ".gitmodules").write_text(textwrap.dedent("""\
+            [submodule "external/hip"]
+                path = external/hip
+                url = https://github.com/ROCm/hip.git
+            [submodule "external/clr"]
+                path = external/clr
+                url = https://github.com/ROCm/clr.git
+        """))
+        base = make_base()
+        url_map = base.get_submodule_url_map(tmp_path)
+        assert url_map["external/hip"] == "https://github.com/ROCm/hip.git"
+        assert url_map["external/clr"] == "https://github.com/ROCm/clr.git"
+
+    def test_missing_url_entry_skipped(self, tmp_path):
+        (tmp_path / ".gitmodules").write_text(textwrap.dedent("""\
+            [submodule "external/hip"]
+                path = external/hip
+        """))
+        base = make_base()
+        assert "external/hip" not in base.get_submodule_url_map(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# RockBase.build_plan — submodule parsing logic
+# ---------------------------------------------------------------------------
+
+class TestBuildPlanSubmoduleParsing:
+    """Test the submodule-filtering logic inside build_plan without a real clone."""
+
+    def _run_build_plan(self, tmp_path, submodule_status, url_map, exclude_list=()):
+        """Drive build_plan with fully mocked git operations."""
+        base = make_base(exclude_list=list(exclude_list))
+        base.cache_root = tmp_path
+
+        clone_dir = tmp_path / "TheRock"
+        clone_dir.mkdir()
+
+        with patch.object(base, "_prepare_clone", return_value=clone_dir), \
+             patch.object(base, "_checkout_and_update_submodules"), \
+             patch.object(
+                 base, "run_command_output",
+                 return_value="\n".join(submodule_status),
+             ), \
+             patch.object(base, "get_submodule_url_map", return_value=url_map):
+            return base.build_plan()
+
+    def test_rocm_submodule_included(self, tmp_path):
+        plan = self._run_build_plan(
+            tmp_path,
+            submodule_status=[f" {'b'*40} external/hip (v6.0)"],
+            url_map={"external/hip": "https://github.com/ROCm/hip.git"},
+        )
+        assert "hip" in plan
+        assert "TheRock" in plan
+
+    def test_non_rocm_submodule_excluded(self, tmp_path):
+        plan = self._run_build_plan(
+            tmp_path,
+            submodule_status=[f" {'b'*40} external/llvm (v17)"],
+            url_map={"external/llvm": "https://github.com/llvm/llvm-project.git"},
+        )
+        assert "llvm-project" not in plan
+
+    def test_excluded_submodule_skipped(self, tmp_path):
+        plan = self._run_build_plan(
+            tmp_path,
+            submodule_status=[f" {'b'*40} external/hip (v6.0)"],
+            url_map={"external/hip": "https://github.com/ROCm/hip.git"},
+            exclude_list=["hip"],
+        )
+        assert "hip" not in plan
+
+    def test_missing_url_in_map_skipped(self, tmp_path):
+        plan = self._run_build_plan(
+            tmp_path,
+            submodule_status=[f" {'b'*40} external/hip (v6.0)"],
+            url_map={},  # no entry for external/hip
+        )
+        assert "hip" not in plan
+
+    def test_therock_always_in_plan(self, tmp_path):
+        plan = self._run_build_plan(
+            tmp_path,
+            submodule_status=[],
+            url_map={},
+        )
+        assert "TheRock" in plan
+        assert plan["TheRock"].commit == _FAKE_COMMIT
+
+    def test_sha_prefix_chars_stripped(self, tmp_path):
+        """Leading -, + in git submodule status output are stripped from the SHA."""
+        plan = self._run_build_plan(
+            tmp_path,
+            submodule_status=[f"-{'b'*40} external/hip"],
+            url_map={"external/hip": "https://github.com/ROCm/hip.git"},
+        )
+        assert plan["hip"].commit == "b" * 40
+
+
+# ---------------------------------------------------------------------------
+# RockBase.run_command — streaming and buffered modes
+# ---------------------------------------------------------------------------
+
+class TestRunCommand:
+    def test_buffered_success_logs_stdout(self, tmp_path):
+        base = make_base()
+        logged = []
+        base._logger.info = lambda msg, *a: logged.append(msg % a if a else msg)
+
+        result = MagicMock()
+        result.stdout = b"hello stdout"
+        result.stderr = b""
+        with patch("subprocess.run", return_value=result):
+            base.run_command(["echo", "hi"], cwd=tmp_path)
+
+        assert any("hello stdout" in m for m in logged)
+
+    def test_buffered_failure_raises(self, tmp_path):
+        base = make_base()
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                base.run_command(["git", "fail"], cwd=tmp_path)
+
+    def test_stream_success(self, tmp_path):
+        base = make_base()
+        proc = MagicMock()
+        proc.stdout = iter(["line1\n", "line2\n"])
+        proc.wait.return_value = 0
+        with patch("subprocess.Popen", return_value=proc):
+            base.run_command(["git", "fetch"], cwd=tmp_path, stream=True)
+
+    def test_stream_nonzero_exit_raises(self, tmp_path):
+        base = make_base()
+        proc = MagicMock()
+        proc.stdout = iter([])
+        proc.wait.return_value = 1
+        with patch("subprocess.Popen", return_value=proc):
+            with pytest.raises(subprocess.CalledProcessError):
+                base.run_command(["git", "fetch"], cwd=tmp_path, stream=True)
+
+    def test_stream_timeout_kills_process(self, tmp_path):
+        base = make_base()
+        proc = MagicMock()
+        proc.stdout = iter([])
+        proc.wait.side_effect = subprocess.TimeoutExpired("git", 10)
+        with patch("subprocess.Popen", return_value=proc):
+            with pytest.raises(subprocess.TimeoutExpired):
+                base.run_command(["git", "fetch"], cwd=tmp_path, stream=True, timeout=10)
+        proc.kill.assert_called_once()

--- a/scripts/tests/test_release_utils.py
+++ b/scripts/tests/test_release_utils.py
@@ -223,6 +223,13 @@ class TestFetchLightweightPlan:
 
         assert "hip" in result
 
+    def test_therock_excluded_when_in_exclude_list(self):
+        mock_resp = _make_gitmodules_response([])
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = fetch_lightweight_plan("token", _FAKE_COMMIT, {"TheRock"})
+
+        assert "TheRock" not in result
+
 
 # ---------------------------------------------------------------------------
 # check_permissions
@@ -452,6 +459,15 @@ class TestBuildPlanSubmoduleParsing:
         )
         assert "TheRock" in plan
         assert plan["TheRock"].commit == _FAKE_COMMIT
+
+    def test_therock_excluded_from_plan(self, tmp_path):
+        plan = self._run_build_plan(
+            tmp_path,
+            submodule_status=[],
+            url_map={},
+            exclude_list=["TheRock"],
+        )
+        assert "TheRock" not in plan
 
     def test_sha_prefix_chars_stripped(self, tmp_path):
         """Leading -, + in git submodule status output are stripped from the SHA."""

--- a/scripts/tests/test_rock_tagging.py
+++ b/scripts/tests/test_rock_tagging.py
@@ -20,7 +20,8 @@ import pytest
 
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-from scripts.rock_tagging import RepoInfo, RockTagging
+from scripts.rock_tagging import RockTagging
+from scripts.release_utils import RepoInfo
 
 
 _FAKE_COMMIT = "a" * 40


### PR DESCRIPTION
  ## Motivation

  When creating release branches across TheRock and its ROCm submodules, the  script could partially succeed — creating branches in some repos but failing silently in others due to insufficient permissions. This leaves the release in an inconsistent state that is difficult to recover from.
This PR adds an upfront GitHub permission check that verifies the authenticated user has push or admin access to every repo before any branches are created. If any repo fails, the entire run aborts with a clear summary.

As part of this work, shared logic between `create_release_branch.py` and  `rock_tagging.py` has been extracted into a new `release_utils.py` module, directly addressing the reviewer feedback about script complexity.

**Note:** The permission check runs in both `--dry-run` and `--no-dry-run`  modes. Only the actual `git push` is skipped in dry-run.

## Changes

  ### `scripts/release_utils.py` (new)

  Shared module extracted from both automation scripts. Contains:

  - `RepoInfo` — dataclass describing a single repo in an execution plan
  - `extract_owner_repo(url)` — parses `(owner, repo)` from HTTPS or SSH GitHub URLs
  - `get_gh_token()` — retrieves the active `gh` CLI token; no `GITHUB_TOKEN` env var required
  - `fetch_lightweight_plan(token, commitid, exclude_list)` — reads `.gitmodules` directly from the GitHub API at the requested commit, building a repo-name
  → URL map without cloning anything locally
  - `check_permissions(token, repo_map, logger, action)` — calls `GET /repos/{owner}/{repo}` for every repo, validates `push` or `admin` access, collects all
  failures before aborting so the user sees the full list in one run
  - `RockBase` — base class with subprocess helpers (`run_command`, `run_command_output`), git helpers (`convert_to_ssh`, `_setup_remote`,
  `get_submodule_url_map`), and `build_plan()` for cloning/reusing a TheRock cache and reading submodule state

  ### `scripts/create_release_branch.py`

  - Reduced from 882 → 232 lines; now contains only branching-specific logic
  - Subclasses `RockBase`; imports permission helpers from `release_utils`
  - `run()` checks permissions via `get_gh_token` + `fetch_lightweight_plan` + `check_permissions` before the expensive clone step

  ### `scripts/rock_tagging.py`

  - Reduced from 692 → 273 lines; now contains only tagging-specific logic
  - Subclasses `RockBase`; imports the same permission helpers from `release_utils`
  - Permission check is now consistent with `create_release_branch.py` (previously absent)

  ### `scripts/tests/test_release_utils.py` (new)

  44 unit tests covering all functions and classes in `release_utils`:

  - `TestExtractOwnerRepo` — HTTPS/SSH, with/without `.git`, invalid URLs
  - `TestGetGhToken` — success, `gh` not found, not authenticated, empty token
  - `TestFetchLightweightPlan` — ROCm filtering, TheRock always included, exclude list, SSH URLs, HTTP/network errors
  - `TestCheckPermissions` — push/admin pass, 403/404/5xx/network/invalid-URL failures, all-repos-checked-before-abort, `action` label in message
  - `TestConvertToSsh` — HTTPS conversion, SSH/non-GitHub passthrough
  - `TestGetSubmoduleUrlMap` — no file, correct parsing, missing URL entry skipped
  - `TestBuildPlanSubmoduleParsing` — ROCm included/excluded, exclude list, TheRock always present, SHA prefix stripping
  - `TestRunCommand` — buffered success/failure, streaming success/nonzero-exit/timeout

  ### `scripts/tests/test_create_release_branch.py`

  - `TestExtractOwnerRepo` and `TestCheckPermissions` updated to call standalone functions from `release_utils` (no longer methods on the class)


  ## Test Plan

  - [x] Run with `gh auth login` and a token that has push access to all repos → should print `Permission Check Passed: all N repo(s)` and proceed
  - [x] Run with a token that lacks push access to one or more repos → should print summary with pass/fail counts and abort before creating any branches
  - [x] Run in both `--dry-run` (default) and `--no-dry-run` modes → permission check fires in both


## Test Result

  ### Unit tests

  scripts/tests/test_release_utils.py::TestExtractOwnerRepo::test_valid_urls[...] PASSED
  scripts/tests/test_release_utils.py::TestGetGhToken::test_returns_token_on_success PASSED
  scripts/tests/test_release_utils.py::TestCheckPermissions::test_push_access_passes PASSED
  scripts/tests/test_release_utils.py::TestCheckPermissions::test_all_repos_checked_before_abort PASSED
  ... (44 tests total)
  scripts/tests/test_create_release_branch.py::TestExtractOwnerRepo::... PASSED
  scripts/tests/test_create_release_branch.py::TestCheckPermissions::... PASSED
  ... (existing tests updated and passing)

  ### Manual test (all repos passing)

  ============================================================
    GitHub Permission Check
    Verifying push/admin access for 11 repo(s)

  INFO Permission check OK: ROCm/TheRock
  INFO Permission check OK: ROCm/llvm-project
  ...

    Permission Check Summary
    Passed : 11 / 11 repo(s)
    Failed : 0 / 11 repo(s)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
