### PR TITLE
feat(ci): plumb build_runs_on through release pytorch wheels workflows

### DIFF
--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -45,6 +45,10 @@ on:
         description: "Single Python version to build (empty for full matrix)"
         type: string
         default: ''
+      build_runs_on:
+        description: "Build runner label"
+        type: string
+        default: "aws-linux-scale-rocm-prod"
 
 permissions:
   id-token: write
@@ -82,6 +86,7 @@ jobs:
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
+      build_runs_on: ${{ inputs.build_runs_on }}
 
   notify_quartz_completed:
     name: "Quartz - completed - release PyTorch wheels (rockrel)"

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -41,6 +41,10 @@ on:
         description: "Single Python version to build (empty for full matrix)"
         type: string
         default: ''
+      build_runs_on:
+        description: "Build runner label"
+        type: string
+        default: "aws-windows-scale-rocm-prod"
 
 permissions:
   id-token: write
@@ -76,6 +80,7 @@ jobs:
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
+      build_runs_on: ${{ inputs.build_runs_on }}
 
   notify_quartz_completed:
     name: "Quartz - completed - release PyTorch wheels (rockrel)"


### PR DESCRIPTION
Pass build_runs_on input to TheRock's release pytorch wheels workflows to allow dynamic build runner selection.

Address [PR 7236 feedback](https://github.com/ROCm/TheRock/pull/7236#discussion_r3752469110): plumb the build_runs_on input through both Linux and Windows release pytorch wheels workflows to allow dynamic build runner selection for release builds.