### PR TITLE
feat: add label-driven Express Train cherry-pick automation

### DIFF
--- a/.github/workflows/express_train_cherry_pick.yml
+++ b/.github/workflows/express_train_cherry_pick.yml
@@ -19,14 +19,19 @@ on:
         description: Read-only plan or draft creation
         required: true
         type: string
+      event_action:
+        description: Source pull request event action
+        required: false
+        default: manual
+        type: string
     secrets:
-      app_id:
+      ROCM_CHERRYPICK_APP_ID:
+        required: false
+      ROCM_CHERRYPICK_APP_PRIVATE_KEY:
+        required: false
+      ROCM_CHERRYPICK_JIRA_URL:
         required: true
-      app_private_key:
-        required: true
-      jira_url:
-        required: true
-      jira_token:
+      ROCM_CHERRYPICK_JIRA_TOKEN:
         required: true
   workflow_dispatch:
     inputs:
@@ -48,6 +53,12 @@ on:
         default: plan
         type: choice
         options: [plan, create-draft]
+      event_action:
+        description: Source pull request event action
+        required: false
+        default: manual
+        type: choice
+        options: [manual, labeled, unlabeled, closed]
 
 permissions:
   contents: read
@@ -90,8 +101,8 @@ jobs:
       - name: Plan request
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          JIRA_URL: ${{ secrets.jira_url || secrets.ROCM_CHERRYPICK_JIRA_URL }}
-          JIRA_TOKEN: ${{ secrets.jira_token || secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
+          JIRA_URL: ${{ secrets.ROCM_CHERRYPICK_JIRA_URL }}
+          JIRA_TOKEN: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
         run: |
           python3 -m scripts.express_train \
             --config config/express-trains.json \
@@ -99,6 +110,7 @@ jobs:
             --source-pr "${{ inputs.source_pr }}" \
             --train "${{ inputs.train_id }}" \
             --repo-dir "$GITHUB_WORKSPACE/source" \
+            --event-action "${{ inputs.event_action }}" \
             --publish-status | tee "$RUNNER_TEMP/express-train-plan.json"
         working-directory: automation
       - name: Upload plan evidence
@@ -125,8 +137,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         with:
-          app-id: ${{ secrets.app_id || secrets.ROCM_CHERRYPICK_APP_ID }}
-          private-key: ${{ secrets.app_private_key || secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}
+          private-key: ${{ secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
           owner: ROCm
           repositories: ${{ steps.source.outputs.name }}
       - name: Check out pinned automation
@@ -146,8 +158,8 @@ jobs:
       - name: Replan and create draft
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          JIRA_URL: ${{ secrets.jira_url || secrets.ROCM_CHERRYPICK_JIRA_URL }}
-          JIRA_TOKEN: ${{ secrets.jira_token || secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
+          JIRA_URL: ${{ secrets.ROCM_CHERRYPICK_JIRA_URL }}
+          JIRA_TOKEN: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
         run: |
           python3 -m scripts.express_train \
             --config config/express-trains.json \
@@ -155,6 +167,7 @@ jobs:
             --source-pr "${{ inputs.source_pr }}" \
             --train "${{ inputs.train_id }}" \
             --repo-dir "$GITHUB_WORKSPACE/source" \
+            --event-action "${{ inputs.event_action }}" \
             --publish-status | tee "$RUNNER_TEMP/express-train-create.json"
         working-directory: automation
       - name: Upload creation evidence

--- a/.github/workflows/express_train_cherry_pick.yml
+++ b/.github/workflows/express_train_cherry_pick.yml
@@ -1,0 +1,166 @@
+name: Express Train cherry-pick
+
+on:
+  workflow_call:
+    inputs:
+      source_pr:
+        description: Canonical GitHub source pull request URL
+        required: true
+        type: string
+      train_id:
+        description: Express Train configuration ID
+        required: true
+        type: string
+      automation_ref:
+        description: Full immutable rockrel commit SHA
+        required: true
+        type: string
+      mode:
+        description: Read-only plan or draft creation
+        required: true
+        type: string
+    secrets:
+      app_id:
+        required: true
+      app_private_key:
+        required: true
+      jira_url:
+        required: true
+      jira_token:
+        required: true
+  workflow_dispatch:
+    inputs:
+      source_pr:
+        description: Canonical GitHub source pull request URL
+        required: true
+        type: string
+      train_id:
+        description: Express Train configuration ID
+        required: true
+        type: string
+      automation_ref:
+        description: Full immutable rockrel commit SHA
+        required: true
+        type: string
+      mode:
+        description: Read-only plan or draft creation
+        required: true
+        default: plan
+        type: choice
+        options: [plan, create-draft]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  plan:
+    name: Validate and plan
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate immutable automation ref
+        env:
+          AUTOMATION_REF: ${{ inputs.automation_ref }}
+        run: |
+          if [[ ! "$AUTOMATION_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "automation_ref must be a full lowercase commit SHA" >&2
+            exit 2
+          fi
+      - name: Resolve source repository
+        id: source
+        env:
+          SOURCE_PR: ${{ inputs.source_pr }}
+        run: |
+          python3 -c 'import os,re; m=re.fullmatch(r"https://github.com/([^/]+)/([^/]+)/pull/[1-9][0-9]*/?", os.environ["SOURCE_PR"]); assert m, "invalid source PR URL"; print(f"repository={m.group(1)}/{m.group(2)}")' >> "$GITHUB_OUTPUT"
+      - name: Check out pinned automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          repository: ROCm/rockrel
+          ref: ${{ inputs.automation_ref }}
+          path: automation
+          persist-credentials: false
+      - name: Check out canonical source repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          repository: ${{ steps.source.outputs.repository }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+      - name: Plan request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          JIRA_URL: ${{ secrets.jira_url || secrets.ROCM_CHERRYPICK_JIRA_URL }}
+          JIRA_TOKEN: ${{ secrets.jira_token || secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
+        run: |
+          python3 -m scripts.express_train \
+            --config config/express-trains.json \
+            plan \
+            --source-pr "${{ inputs.source_pr }}" \
+            --train "${{ inputs.train_id }}" \
+            --repo-dir "$GITHUB_WORKSPACE/source" \
+            --publish-status | tee "$RUNNER_TEMP/express-train-plan.json"
+        working-directory: automation
+      - name: Upload plan evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: express-train-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/express-train-plan.json
+          if-no-files-found: warn
+
+  create-draft:
+    name: Create draft
+    if: inputs.mode == 'create-draft'
+    needs: plan
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Resolve source repository
+        id: source
+        env:
+          SOURCE_PR: ${{ inputs.source_pr }}
+        run: |
+          python3 -c 'import os,re; m=re.fullmatch(r"https://github.com/([^/]+)/([^/]+)/pull/[1-9][0-9]*/?", os.environ["SOURCE_PR"]); assert m, "invalid source PR URL"; print(f"repository={m.group(1)}/{m.group(2)}"); print(f"name={m.group(2)}")' >> "$GITHUB_OUTPUT"
+      - name: Create scoped GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.app_id || secrets.ROCM_CHERRYPICK_APP_ID }}
+          private-key: ${{ secrets.app_private_key || secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
+          owner: ROCm
+          repositories: ${{ steps.source.outputs.name }}
+      - name: Check out pinned automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          repository: ROCm/rockrel
+          ref: ${{ inputs.automation_ref }}
+          path: automation
+          persist-credentials: false
+      - name: Check out canonical source repository with App credentials
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          repository: ${{ steps.source.outputs.repository }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          path: source
+      - name: Replan and create draft
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          JIRA_URL: ${{ secrets.jira_url || secrets.ROCM_CHERRYPICK_JIRA_URL }}
+          JIRA_TOKEN: ${{ secrets.jira_token || secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
+        run: |
+          python3 -m scripts.express_train \
+            --config config/express-trains.json \
+            create-draft \
+            --source-pr "${{ inputs.source_pr }}" \
+            --train "${{ inputs.train_id }}" \
+            --repo-dir "$GITHUB_WORKSPACE/source" \
+            --publish-status | tee "$RUNNER_TEMP/express-train-create.json"
+        working-directory: automation
+      - name: Upload creation evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: express-train-create-${{ github.run_id }}
+          path: ${{ runner.temp }}/express-train-create.json
+          if-no-files-found: warn

--- a/.github/workflows/express_train_cherry_pick.yml
+++ b/.github/workflows/express_train_cherry_pick.yml
@@ -69,6 +69,9 @@ jobs:
   plan:
     name: Validate and plan
     runs-on: ubuntu-24.04
+    outputs:
+      status: ${{ steps.result.outputs.status }}
+      train_mode: ${{ steps.result.outputs.train_mode }}
     steps:
       - name: Validate immutable automation ref
         env:
@@ -113,6 +116,12 @@ jobs:
             --event-action "${{ inputs.event_action }}" \
             --publish-status | tee "$RUNNER_TEMP/express-train-plan.json"
         working-directory: automation
+      - name: Export plan decision
+        id: result
+        run: |
+          python3 -c 'import json,os; value=json.load(open(os.environ["PLAN_FILE"])); print("status={}".format(value["status"])); print("train_mode={}".format(value["evidence"]["train_mode"]))' >> "$GITHUB_OUTPUT"
+        env:
+          PLAN_FILE: ${{ runner.temp }}/express-train-plan.json
       - name: Upload plan evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -123,7 +132,10 @@ jobs:
 
   create-draft:
     name: Create draft
-    if: inputs.mode == 'create-draft'
+    if: >-
+      inputs.mode == 'create-draft' &&
+      needs.plan.outputs.train_mode == 'create-draft' &&
+      needs.plan.outputs.status == 'cherry_pick_required'
     needs: plan
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/express_train_reconcile.yml
+++ b/.github/workflows/express_train_reconcile.yml
@@ -1,0 +1,122 @@
+name: Reconcile Express Train requests
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      train_id:
+        description: Express Train ID, or leave empty for every active train
+        required: false
+        type: string
+      automation_ref:
+        description: Full immutable rockrel commit SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-24.04
+    outputs:
+      trains: ${{ steps.trains.outputs.trains }}
+      automation_ref: ${{ steps.ref.outputs.value }}
+    steps:
+      - name: Resolve automation ref
+        id: ref
+        env:
+          REQUESTED_REF: ${{ inputs.automation_ref }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          value="${REQUESTED_REF:-$CURRENT_SHA}"
+          if [[ ! "$value" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "automation_ref must be a full lowercase commit SHA" >&2
+            exit 2
+          fi
+          echo "value=$value" >> "$GITHUB_OUTPUT"
+      - name: Check out pinned automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ steps.ref.outputs.value }}
+          persist-credentials: false
+      - name: Select active trains
+        id: trains
+        env:
+          REQUESTED_TRAIN: ${{ inputs.train_id }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          config = json.load(open("config/express-trains.json"))
+          requested = os.environ.get("REQUESTED_TRAIN", "")
+          trains = [item["id"] for item in config["trains"] if item["state"] == "active"]
+          if requested:
+              if requested not in trains:
+                  raise SystemExit(f"requested train is not active: {requested}")
+              trains = [requested]
+          print(f"trains={json.dumps(trains)}")
+          PY
+
+  reconcile:
+    needs: discover
+    if: needs.discover.outputs.trains != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        train: ${{ fromJSON(needs.discover.outputs.trains) }}
+    runs-on: ubuntu-24.04
+    env:
+      mode: plan
+    steps:
+      - name: Check out pinned automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.discover.outputs.automation_ref }}
+          path: automation
+          persist-credentials: false
+      - name: Check out TheRock
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          repository: ROCm/TheRock
+          fetch-depth: 0
+          path: sources/TheRock
+          persist-credentials: false
+      - name: Check out rocm-systems
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          repository: ROCm/rocm-systems
+          fetch-depth: 0
+          path: sources/rocm-systems
+          persist-credentials: false
+      - name: Check out rocm-libraries
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          repository: ROCm/rocm-libraries
+          fetch-depth: 0
+          path: sources/rocm-libraries
+          persist-credentials: false
+      - name: Reconcile labeled merged pull requests in plan mode
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          JIRA_URL: ${{ secrets.ROCM_CHERRYPICK_JIRA_URL }}
+          JIRA_TOKEN: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
+        run: |
+          python3 -m scripts.express_train \
+            --config config/express-trains.json \
+            reconcile \
+            --train "${{ matrix.train }}" \
+            --repo-dir "ROCm/TheRock=$GITHUB_WORKSPACE/sources/TheRock" \
+            --repo-dir "ROCm/rocm-systems=$GITHUB_WORKSPACE/sources/rocm-systems" \
+            --repo-dir "ROCm/rocm-libraries=$GITHUB_WORKSPACE/sources/rocm-libraries" \
+            | tee "$RUNNER_TEMP/express-train-reconcile.json"
+        working-directory: automation
+      - name: Upload reconciliation evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: express-train-reconcile-${{ matrix.train }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/express-train-reconcile.json
+          if-no-files-found: warn

--- a/.github/workflows/express_train_sync_labels.yml
+++ b/.github/workflows/express_train_sync_labels.yml
@@ -1,0 +1,45 @@
+name: Synchronize Express Train labels
+
+on:
+  workflow_dispatch:
+    inputs:
+      train_id:
+        description: Express Train ID
+        required: true
+        type: string
+      automation_ref:
+        description: Full immutable rockrel commit SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create scoped GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}
+          private-key: ${{ secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
+          owner: ROCm
+          repositories: |-
+            TheRock
+            rocm-systems
+            rocm-libraries
+      - name: Check out pinned automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ inputs.automation_ref }}
+          persist-credentials: false
+      - name: Synchronize labels
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python3 -m scripts.express_train \
+            --config config/express-trains.json \
+            sync-labels \
+            --train "${{ inputs.train_id }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+.venv/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Per-commit builds | [TheRock](https://github.com/ROCm/TheRock), [rocm-libraries]
 
 _The name of this repo has been shortened to workaround this [known Windows path length issue](https://github.com/ROCm/rocm-libraries/issues/2096)._
 
+## Express Train cherry-pick automation
+
+The label-triggered, draft-only Express Train cherry-pick workflow is documented
+in the [product requirements](docs/cherry-pick-automation/product-requirements.md),
+[technical design](docs/cherry-pick-automation/technical-design.md), and
+[operator runbook](docs/cherry-pick-automation/runbook.md). Train-to-branch and
+Jira Fix Version mappings are version controlled in
+[`config/express-trains.json`](config/express-trains.json).
+
 ## Release FAQ (Frequently Asked Questions)
 
 ### Why are some packages included in nightly releases but missing from stable releases?

--- a/config/express-trains.json
+++ b/config/express-trains.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "trains": [
+    {
+      "id": "10.1-20260811",
+      "jira_fix_version": "10.1.0a20260811",
+      "state": "active",
+      "mode": "validate",
+      "repositories": {
+        "ROCm/TheRock": {
+          "source_branch": "main",
+          "target_branch": "release/bkc/therock-10.1-20260811"
+        },
+        "ROCm/rocm-systems": {
+          "source_branch": "develop",
+          "target_branch": "release/bkc/therock-10.1-20260811"
+        },
+        "ROCm/rocm-libraries": {
+          "source_branch": "develop",
+          "target_branch": "release/bkc/therock-10.1-20260811"
+        }
+      }
+    }
+  ]
+}

--- a/docs/cherry-pick-automation/implementation-report.md
+++ b/docs/cherry-pick-automation/implementation-report.md
@@ -35,6 +35,7 @@ The Git history preserves red tests before each implementation slice:
 | `a19b8da` unlabeled cancellation | `d3c6ded` event handling |
 | `10c4b70`, `1187b5c` covering evidence | `82cefb6` coverage detector |
 | `86b2c05` immutable renderer | `66ca3cd` renderer |
+| `9fb1439` validation-mode token boundary | `f3438b6` conditional write-token job |
 
 Each red state was run locally and failed for the intended missing module,
 interface, or workflow behavior. Red commits were not pushed independently.

--- a/docs/cherry-pick-automation/implementation-report.md
+++ b/docs/cherry-pick-automation/implementation-report.md
@@ -1,0 +1,76 @@
+# Express Train cherry-pick automation implementation report
+
+## Delivered
+
+- Product requirements, technical design, and operator runbook were committed
+  before production code.
+- Train configuration and label parsing are fail-closed.
+- Qualification validates repository, base branch, label actor permission, Jira
+  Fix Version, target existence, and target protection.
+- Git planning uses disposable worktrees for contained, clean, empty, conflict,
+  merge-commit, and gitlink cases.
+- GitHub and Jira clients use injectable transports and bounded requests.
+- Existing identity markers, deterministic branches, ordinary patch coverage,
+  and gitlink cherry-pick provenance prevent duplicate PRs.
+- The write path uses a target-head lease, `git cherry-pick -x`, a deterministic
+  branch, and GitHub's `draft: true` API field.
+- The implementation has no ready-for-review, review, merge, or auto-merge API.
+- Reusable, reconciliation, label-sync, and source-template workflows pin every
+  external action to a full SHA and pass actionlint.
+
+## Test-first record
+
+The Git history preserves red tests before each implementation slice:
+
+| Test commit | Green implementation |
+| --- | --- |
+| `324b48e` configuration contract | `cb99967` configuration loader |
+| `fae38bb` qualification policy | `bb2eb40` qualification implementation |
+| `dafd198` Git decisions | `f0f7dd8` disposable Git planner |
+| `3afafc1` API contracts | `1a06ed4` GitHub/Jira clients |
+| `32ed8fc` orchestration | `b3938a6` request planner |
+| `5f48c8b` write transaction | `3b68e0b` draft writer |
+| `6b98342` CLI contract | `14e0b89` CLI |
+| `100d24b`, `e5f87a3`, `3fd5865` workflows/reconciliation | `38441df` workflows |
+| `a19b8da` unlabeled cancellation | `d3c6ded` event handling |
+| `10c4b70`, `1187b5c` covering evidence | `82cefb6` coverage detector |
+| `86b2c05` immutable renderer | `66ca3cd` renderer |
+
+Each red state was run locally and failed for the intended missing module,
+interface, or workflow behavior. Red commits were not pushed independently.
+
+## Final verification
+
+Run from the rockrel checkout:
+
+```text
+.venv/bin/python -m pytest -q scripts/tests
+.venv/bin/pre-commit run --all-files
+git diff --check
+```
+
+Results on 2026-08-14:
+
+- 132 tests passed.
+- Trailing whitespace, EOF, YAML, merge-conflict, large-file, line-ending,
+  no-tabs, and actionlint hooks passed.
+- The seven 0811 requests are captured in
+  `scripts/tests/fixtures/express_train_0811.json`.
+- Live read-only validation of TheRock #7282 against #7357 returned
+  `gitlink_cherry_pick_provenance`, using desired pin `a01cdbd92d1f`, covering
+  pin `d177931e65e6`, and common original commit `1109d68feb1b`.
+
+## Activation prerequisites
+
+Engineering implementation does not itself grant production authority. Before
+write mode can run, an ROCm organization administrator must:
+
+1. Install the dedicated GitHub App on rockrel, TheRock, rocm-systems, and
+   rocm-libraries with the permissions in the technical design.
+2. Configure the four selected-repository secrets documented in the runbook.
+3. Review and merge the central rockrel workflow.
+4. Review source-repository caller PRs pinned to the immutable central commit.
+5. Run validation and shadow modes before changing a train to `create-draft`.
+
+All initial train configuration remains in `validate` mode. No production
+cherry-pick branch can be created from the committed configuration.

--- a/docs/cherry-pick-automation/product-requirements.md
+++ b/docs/cherry-pick-automation/product-requirements.md
@@ -1,0 +1,152 @@
+# Express Train cherry-pick automation: product requirements
+
+## Problem
+
+ROCm Express Train operators currently translate a list of qualifying pull
+requests into release-branch cherry-pick pull requests by hand. The work spans
+TheRock, rocm-systems, and rocm-libraries, is sensitive to the exact source and
+target branches, and is easy to duplicate or apply to the wrong train.
+
+The product will provide a GitHub-native request mechanism: an authorized
+operator labels a source pull request with an Express Train identifier. After
+the source pull request is merged, automation validates the request and creates
+a draft pull request against the configured release branch.
+
+The operator experience is modeled on LinkedIn's label-driven cherry-pick
+automation, but ROCm deliberately retains manual review and merge control.
+
+## Goals
+
+- Make a repository label the primary cherry-pick request interface.
+- Validate the train, repository, source branch, labeler, Jira Fix Version, and
+  target branch before writing anything.
+- Produce at most one draft pull request per source PR, repository, and train.
+- Detect changes that are already contained or covered by an existing pull
+  request instead of creating duplicates.
+- Report a durable, understandable status on the source pull request.
+- Recover safely from duplicate events, target movement, and interrupted runs.
+- Keep policy and implementation centralized in ROCm/rockrel.
+
+## Non-goals
+
+- Automatically marking generated pull requests ready for review.
+- Automatically approving, merging, or enabling auto-merge.
+- Resolving cherry-pick conflicts automatically.
+- Inferring dependency ordering from prose.
+- Creating a second TheRock pin update for a component-repository request.
+- Replacing Jira, GitHub branch rules, CI, or required reviewers.
+
+## Users
+
+- **Express Train operator:** configures trains, applies labels, reviews results,
+  and decides when generated drafts are ready.
+- **Source PR author:** receives status and remediation details on the original
+  pull request.
+- **Repository maintainer:** reviews the generated draft under the target
+  repository's normal branch rules.
+- **Automation administrator:** installs the GitHub App, manages secrets, and
+  disables or replays automation.
+
+## User experience
+
+### Request
+
+An operator applies a repository label with this exact form:
+
+```text
+express-train:<train-id>
+```
+
+Example:
+
+```text
+express-train:10.1-20260811
+```
+
+The train ID is stable operator-facing vocabulary. A version-controlled rockrel
+configuration maps it to exact repository branches and the Jira Fix Version.
+
+Labels may be applied before merge or after merge. A valid post-merge label is
+an explicit recovery request and runs immediately.
+
+### Qualification
+
+A request qualifies only when all of the following are true:
+
+1. The label maps to an active train.
+2. The source repository is TheRock, rocm-systems, or rocm-libraries.
+3. The source PR base is `main` for TheRock or `develop` for the component
+   repositories.
+4. The actor that applied the label currently has `write`, `maintain`, or
+   `admin` permission in that repository.
+5. The source PR is merged and its aggregate merge commit is available from the
+   canonical repository.
+6. At least one ROCm Jira issue referenced by the PR has the exact Fix Version
+   configured for the train.
+7. The configured target branch exists and is governed by pull-request rules.
+
+An open qualifying PR receives `waiting_for_merge`. Closing without merge or
+removing the label records `cancelled`.
+
+### Outcomes
+
+Each source PR/train pair has exactly one current outcome:
+
+| Status | Meaning | Write behavior |
+| --- | --- | --- |
+| `waiting_for_merge` | Request is valid but the source is open | None |
+| `invalid` | A deterministic policy rule failed | Remove invalid train label |
+| `blocked` | Required evidence or a service is temporarily unavailable | None; retain label |
+| `already_contained` | Exact target already contains the change | None |
+| `covered_by_existing_pr` | An existing target PR covers the change | None |
+| `cherry_pick_required` | Read-only planning proved a clean change is needed | None |
+| `draft_created` | A draft target PR exists | Draft only |
+| `manual_resolution_required` | Conflict or ambiguous repository state | None |
+| `cancelled` | Request was removed or PR closed without merge | None |
+
+Automation updates one sticky source-PR comment instead of adding a comment for
+every delivery. The comment identifies the train, decision, evidence summary,
+workflow run, and generated or covering PR when applicable.
+
+## Safety requirements
+
+- Generated pull requests are always drafts.
+- The automation has no code path or permission request for ready-for-review,
+  approval, merge, or auto-merge operations.
+- A conflict is never treated as evidence that the change is present.
+- Every decision uses freshly fetched canonical refs.
+- Before push, the target head is fetched again. One target movement causes a
+  complete recomputation; a second movement stops the run safely.
+- `pull_request_target` workflows never check out or execute the source PR head.
+- Temporary GitHub or Jira failures retain the label and create no branch.
+- Dry-run and shadow modes cannot acquire write credentials.
+
+## Configuration and lifecycle
+
+Each train declares an ID, Jira Fix Version, state, mode, and per-repository
+source and target branches. Supported states are `active` and `inactive`.
+Supported modes are `disabled`, `validate`, `shadow`, and `create-draft`.
+
+Activating a train synchronizes its label to the three supported repositories.
+Inactivating a train prevents new requests without deleting historical labels
+or comments.
+
+## Success criteria
+
+- Applying a valid label to a merged qualifying PR creates exactly one draft
+  against the configured target branch.
+- Replaying the same request has no additional write effect.
+- Invalid requests explain the exact failed rule.
+- Existing or covering changes do not produce duplicate PRs.
+- Conflicts produce no remote branch.
+- All seven 0811 reference cases resolve deterministically, including TheRock
+  PR 7282 being associated with its existing covering descendant-pin PR.
+- A later nightly or similarly named release never substitutes for the exact
+  configured target.
+- Unit, Git integration, contract, workflow, and security tests pass.
+
+## Rollout
+
+Rollout progresses through `validate`, `shadow`, and `create-draft`. The first
+live write is a controlled pilot. Expanding writes requires operator review of
+the pilot result. Production enablement does not relax the draft-only rule.

--- a/docs/cherry-pick-automation/runbook.md
+++ b/docs/cherry-pick-automation/runbook.md
@@ -1,0 +1,83 @@
+# Express Train cherry-pick automation runbook
+
+## Operating principles
+
+- Labels request work; they do not approve or merge it.
+- Every generated pull request remains a draft until an operator acts.
+- Use `plan` before replaying any failed write.
+- Do not interpret a conflict as proof that a change is already present.
+- Disable a train in configuration to stop new work without deleting evidence.
+
+## Add a train
+
+1. Add a unique train entry to `config/express-trains.json` in `validate` mode.
+2. Confirm exact source and target branches for all enabled repositories.
+3. Confirm the Jira Fix Version spelling with Jira.
+4. Run the configuration and workflow test suites.
+5. Review and merge the configuration pull request.
+6. Dispatch the label synchronization workflow for the train.
+7. Apply the label to a non-production fixture PR and inspect the sticky status.
+8. Promote to `shadow`, then `create-draft` only after operator review.
+
+## Review a generated draft
+
+1. Confirm the source PR URL, aggregate merge SHA, Jira issue, and train ID.
+2. Confirm the draft base is the exact configured release branch.
+3. Review the cherry-picked diff and provenance marker.
+4. Distinguish target-branch CI from checks inherited from the source PR.
+5. Resolve dependency ordering with the component owner when Jira records a
+   dependency.
+6. An operator may mark the draft ready only after completing this review.
+
+The automation never performs step 6.
+
+## Replay
+
+Run the manual workflow in `plan` mode with the source PR URL and train ID. If
+the plan is `cherry_pick_required`, review the exact target head and then
+dispatch `create-draft`. Replays are idempotent and return an existing branch or
+PR when one is already associated with the identity key.
+
+## Conflict
+
+When the status is `manual_resolution_required`:
+
+1. Download the JSON evidence artifact.
+2. Reproduce the trial cherry-pick in a disposable worktree.
+3. Consult the owning component team for ambiguous or diverged histories.
+4. Create a separate manual draft PR when a reviewed resolution is available.
+5. Add the source/train provenance marker so reconciliation recognizes it.
+
+Do not force the automation branch or alter the source status to
+`already_contained` merely because a conflict occurred.
+
+## Covering PR closes without merge
+
+The scheduled reconciler reevaluates labeled, merged source PRs. If a recorded
+covering PR closes without merge and the change remains absent, the next run
+will return `cherry_pick_required` and, in write mode, create a draft.
+
+## Disable or roll back
+
+Set the affected train mode to `disabled` for an immediate fail-closed stop.
+Retain labels and comments for auditability. If configuration cannot be merged
+quickly, disable the GitHub App installation for the affected repositories or
+remove access to the write environment. Do not delete generated branches or
+draft PRs automatically.
+
+## Credential rotation
+
+1. Generate the replacement GitHub App key or Jira token.
+2. Update the selected-repository organization secret.
+3. Run a read-only validation workflow.
+4. Revoke the previous credential.
+5. Verify logs and artifacts contain no secret material.
+
+## Operator handoff checklist
+
+- Product requirements and technical design match deployed behavior.
+- Final unit, integration, workflow, and security tests pass.
+- Shadow results are attached for representative requests.
+- App installation repositories and permissions are recorded.
+- Train configuration, Jira Fix Version, and exact target branches are recorded.
+- Generated implementation and pilot pull requests are still drafts.

--- a/docs/cherry-pick-automation/technical-design.md
+++ b/docs/cherry-pick-automation/technical-design.md
@@ -1,0 +1,178 @@
+# Express Train cherry-pick automation: technical design
+
+## Architecture
+
+The system uses thin event workflows in TheRock, rocm-systems, and
+rocm-libraries and a reusable implementation workflow in rockrel. Source
+workflows listen to `pull_request_target` events `labeled`, `unlabeled`, and
+`closed`. They pass immutable event metadata to a rockrel workflow referenced by
+a full commit SHA.
+
+The reusable workflow checks out rockrel itself at the same explicitly supplied
+SHA and invokes a standard-library Python CLI. It does not check out an
+unmerged pull-request head. A separate scheduled workflow reconciles merged,
+labeled PRs after missed deliveries or abandoned covering PRs.
+
+## Components
+
+- `scripts/express_train/`: policy, GitHub/Jira clients, git decision engine,
+  orchestration, and CLI.
+- `config/express-trains.json`: version-controlled train definitions.
+- `.github/workflows/express_train_cherry_pick.yml`: reusable and manual entry
+  point.
+- `.github/workflows/express_train_reconcile.yml`: scheduled/manual recovery.
+- `.github/workflows/express_train_sync_labels.yml`: label provisioning.
+- A small `.github/workflows/express_train_request.yml` caller in each source
+  repository.
+
+## Configuration contract
+
+The root JSON object has `schema_version` and `trains`. Each train has:
+
+```json
+{
+  "id": "10.1-20260811",
+  "jira_fix_version": "10.1.0a20260811",
+  "state": "active",
+  "mode": "validate",
+  "repositories": {
+    "ROCm/TheRock": {
+      "source_branch": "main",
+      "target_branch": "release/bkc/therock-10.1-20260811"
+    }
+  }
+}
+```
+
+Repository keys must be unique and drawn from the allowlist. Train IDs must
+match `[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}`. Target branches must begin with
+`release/`. Duplicate labels or repository mappings are rejected at load time.
+
+## Command contract
+
+The module exposes:
+
+```text
+python -m scripts.express_train plan --source-pr URL --train ID --json
+python -m scripts.express_train create-draft --source-pr URL --train ID --json
+python -m scripts.express_train reconcile --train ID --json
+python -m scripts.express_train sync-labels --train ID --json
+```
+
+Commands write one JSON result to stdout and diagnostics to stderr. `plan` is
+read-only. `create-draft` checks the configured mode and refuses to write unless
+it is `create-draft`. Reconciliation delegates each discovered request through
+the same planner and writer; it has no separate decision logic.
+
+The result contains `status`, `reason_code`, source and target identifiers,
+fresh ref SHAs, Jira evidence, containment evidence, optional covering or
+created PR URL, and a workflow correlation ID.
+
+## Event handling
+
+1. Parse the repository, PR number, action, label, and sender from the event.
+2. Ignore labels outside the `express-train:` namespace.
+3. Resolve the named train from the pinned configuration.
+4. For `unlabeled` or an unmerged `closed`, update the sticky status to
+   `cancelled`.
+5. Validate the label actor from the PR timeline and current repository
+   permission.
+6. Validate source base, Jira Fix Version, and exact target branch.
+7. If open, report `waiting_for_merge`; if merged, build a plan.
+8. In `validate` or `shadow`, report the plan without obtaining write tokens.
+9. In `create-draft`, execute only a `cherry_pick_required` plan.
+
+Deterministic validation failures may remove the train label. Transport errors,
+rate limits, timeouts, and unavailable evidence return `blocked` and retain it.
+
+## Git decision engine
+
+All Git operations use argument arrays with `shell=False`. The engine creates a
+disposable clone or worktree and fetches the exact canonical source commit and
+target ref.
+
+Decision order:
+
+1. Verify the source PR is merged and identify its aggregate merge commit.
+2. Fetch the exact target head.
+3. Search target PRs for an idempotency marker or deterministic automation
+   branch.
+4. Test whether the source is already reachable from the target.
+5. For ordinary commits, test a no-commit cherry-pick in a disposable worktree.
+6. For TheRock gitlink changes, compare old, desired, and target component pins
+   directionally using component-repository ancestry.
+7. Search open target PR heads for exact source markers and proven coverage.
+8. Return `cherry_pick_required` only when applying the aggregate change is
+   clean and non-empty.
+
+An empty trial application is supporting evidence but does not by itself equate
+arbitrary commits. A conflict returns `manual_resolution_required`. The engine
+never modifies the operator's checkout.
+
+## Idempotency and writes
+
+The identity key is source repository, source PR number, and train ID. Generated
+branches use:
+
+```text
+shared/cherry-pick/<train-id>/<source-pr-number>
+```
+
+Generated PR bodies include an HTML marker containing the identity key and
+source merge SHA. Before push, the writer refetches the target and compares it
+with the planned head. It recomputes once on movement and stops on a second
+race.
+
+The writer uses `git cherry-pick -x`, pushes with an expected old-object lease,
+and creates a draft PR. If push succeeds but PR creation fails, replay reuses the
+same branch. Existing marker, branch, draft, merged PR, or proven covering PR
+prevents a duplicate.
+
+## GitHub and Jira access
+
+A dedicated GitHub App is installed only on rockrel, TheRock, rocm-systems, and
+rocm-libraries with repository permissions:
+
+- Metadata: read
+- Contents: write
+- Pull requests: write
+- Issues: write
+- Administration: read
+
+Jira credentials and the GitHub App ID/private key are organization Actions
+secrets restricted to those repositories and passed by explicit name. Read-only
+modes do not generate an App installation token with write permissions.
+
+## Security boundaries
+
+- The privileged event is `pull_request_target`, but source PR code and
+  artifacts are never checked out, imported, sourced, or executed.
+- Reusable workflow references and the rockrel checkout use the same full SHA.
+- Workflow permissions are explicit and default to read-only.
+- User-controlled titles, bodies, labels, and branch names are passed as data,
+  never interpolated into shell scripts.
+- Logs redact Authorization, App private keys, Jira tokens, and installation
+  tokens.
+- Draft creation is the terminal write operation; the implementation contains
+  no ready, review, merge, or auto-merge client method.
+
+## Testing strategy
+
+Development is red-green-refactor. Unit tests cover configuration, policies,
+events, result serialization, and client behavior. Git integration tests create
+disposable bare repositories for contained, clean, conflicting, racing, and
+gitlink histories. HTTP clients use injectable transports and deterministic
+fixtures. Workflow contract tests parse YAML as text and actionlint validates
+syntax.
+
+The seven 0811 candidates form a regression corpus. Live validation remains
+read-only until the shadow results match expected outcomes.
+
+## Deployment
+
+1. Merge central rockrel automation after operator review.
+2. Pin source-repository callers to the immutable merged SHA.
+3. Install the App and configure selected-repository secrets.
+4. Activate `validate`, then `shadow`, then one `create-draft` pilot.
+5. Disable writes by changing train mode; workflow removal is not required for
+   rollback.

--- a/scripts/express_train/__init__.py
+++ b/scripts/express_train/__init__.py
@@ -1,0 +1,5 @@
+"""ROCm Express Train cherry-pick automation."""
+
+from .models import Result, Status
+
+__all__ = ["Result", "Status"]

--- a/scripts/express_train/__main__.py
+++ b/scripts/express_train/__main__.py
@@ -32,6 +32,11 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument("--train", required=True)
         subparser.add_argument("--repo-dir", type=Path, required=True)
         subparser.add_argument("--publish-status", action="store_true")
+        subparser.add_argument(
+            "--event-action",
+            choices=("labeled", "unlabeled", "closed", "manual"),
+            default="manual",
+        )
 
     sync = subparsers.add_parser("sync-labels")
     sync.add_argument("--train", required=True)
@@ -163,7 +168,12 @@ def main(
         )
         return 0
 
-    result = planner.plan(args.source_pr, args.train, args.repo_dir)
+    result = planner.plan(
+        args.source_pr,
+        args.train,
+        args.repo_dir,
+        event_action=args.event_action,
+    )
 
     if args.command == "create-draft":
         writer = writer_factory(github)

--- a/scripts/express_train/__main__.py
+++ b/scripts/express_train/__main__.py
@@ -35,6 +35,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     sync = subparsers.add_parser("sync-labels")
     sync.add_argument("--train", required=True)
+
+    reconcile = subparsers.add_parser("reconcile")
+    reconcile.add_argument("--train", required=True)
+    reconcile.add_argument(
+        "--repo-dir",
+        action="append",
+        required=True,
+        metavar="OWNER/REPO=PATH",
+        help="Repeat once for every repository configured for the train.",
+    )
+    reconcile.add_argument("--publish-status", action="store_true")
     return parser
 
 
@@ -97,6 +108,61 @@ def main(
         return 2
     jira = jira_factory(jira_url, jira_token)
     planner = planner_factory(config, github, jira)
+
+    if args.command == "reconcile":
+        repo_directories: dict[str, Path] = {}
+        for assignment in args.repo_dir:
+            if "=" not in assignment:
+                print(
+                    f"error: --repo-dir must be OWNER/REPO=PATH, got {assignment!r}",
+                    file=stderr,
+                )
+                return 2
+            repository, directory = assignment.split("=", 1)
+            repo_directories[repository] = Path(directory)
+        missing = sorted(set(train.repositories) - set(repo_directories))
+        if missing:
+            print(
+                "error: missing --repo-dir mappings for " + ", ".join(missing),
+                file=stderr,
+            )
+            return 2
+        results = []
+        for repository in train.repositories:
+            owner, repo = repository.split("/", 1)
+            source_urls = github.search_merged_labeled_pull_requests(
+                owner, repo, train.label
+            )
+            for source_url in source_urls:
+                result = planner.plan(
+                    source_url, train.id, repo_directories[repository]
+                )
+                if args.publish_status:
+                    source_owner, source_repo, number = parse_pull_request_url(
+                        source_url
+                    )
+                    github.upsert_comment(
+                        source_owner,
+                        source_repo,
+                        number,
+                        marker=status_marker(train.id),
+                        body=render_status_comment(result),
+                    )
+                results.append(result.as_dict())
+        print(
+            json.dumps(
+                {
+                    "status": "reconciled",
+                    "mode": "plan",
+                    "train_id": train.id,
+                    "results": results,
+                },
+                sort_keys=True,
+            ),
+            file=stdout,
+        )
+        return 0
+
     result = planner.plan(args.source_pr, args.train, args.repo_dir)
 
     if args.command == "create-draft":

--- a/scripts/express_train/__main__.py
+++ b/scripts/express_train/__main__.py
@@ -1,0 +1,123 @@
+"""Command-line entry point for Express Train cherry-pick automation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TextIO
+
+from .clients import GitHubClient, JiraClient, parse_pull_request_url
+from .config import load_config
+from .orchestrator import Planner, render_status_comment, status_marker
+from .writer import DraftWriter
+
+
+DEFAULT_CONFIG = Path(__file__).parents[2] / "config" / "express-trains.json"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Plan and create draft ROCm Express Train cherry-picks."
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in ("plan", "create-draft"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--source-pr", required=True)
+        subparser.add_argument("--train", required=True)
+        subparser.add_argument("--repo-dir", type=Path, required=True)
+        subparser.add_argument("--publish-status", action="store_true")
+
+    sync = subparsers.add_parser("sync-labels")
+    sync.add_argument("--train", required=True)
+    return parser
+
+
+def _credential(
+    environ: Mapping[str, str], name: str, stderr: TextIO
+) -> str | None:
+    value = environ.get(name)
+    if value:
+        return value
+    print(f"error: required environment variable {name} is not set", file=stderr)
+    return None
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    environ: Mapping[str, str] = os.environ,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+    github_factory=GitHubClient,
+    jira_factory=JiraClient,
+    planner_factory=Planner,
+    writer_factory=DraftWriter,
+) -> int:
+    args = build_parser().parse_args(argv)
+    github_token = _credential(environ, "GITHUB_TOKEN", stderr)
+    if github_token is None:
+        return 2
+    github = github_factory(github_token)
+    config = load_config(args.config)
+    train = config.train(args.train)
+
+    if args.command == "sync-labels":
+        for repository in train.repositories:
+            owner, repo = repository.split("/", 1)
+            github.ensure_label(
+                owner,
+                repo,
+                name=train.label,
+                description=(
+                    f"Request a draft cherry-pick for Express Train {train.id}"
+                ),
+            )
+        print(
+            json.dumps(
+                {
+                    "status": "labels_synchronized",
+                    "train_id": train.id,
+                    "repositories": sorted(train.repositories),
+                },
+                sort_keys=True,
+            ),
+            file=stdout,
+        )
+        return 0
+
+    jira_url = _credential(environ, "JIRA_URL", stderr)
+    jira_token = _credential(environ, "JIRA_TOKEN", stderr)
+    if jira_url is None or jira_token is None:
+        return 2
+    jira = jira_factory(jira_url, jira_token)
+    planner = planner_factory(config, github, jira)
+    result = planner.plan(args.source_pr, args.train, args.repo_dir)
+
+    if args.command == "create-draft":
+        writer = writer_factory(github)
+        result = writer.create(args.repo_dir, train, result)
+
+    if args.publish_status:
+        owner, repo, number = parse_pull_request_url(args.source_pr)
+        github.upsert_comment(
+            owner,
+            repo,
+            number,
+            marker=status_marker(args.train),
+            body=render_status_comment(result),
+        )
+        if result.status.value == "invalid":
+            github.remove_label(owner, repo, number, train.label)
+
+    print(json.dumps(result.as_dict(), sort_keys=True), file=stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/express_train/clients.py
+++ b/scripts/express_train/clients.py
@@ -1,0 +1,313 @@
+"""Minimal injectable REST clients for GitHub and Jira."""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+GITHUB_ACCEPT = "application/vnd.github+json"
+GITHUB_API_VERSION = "2022-11-28"
+PR_URL_RE = re.compile(
+    r"https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([1-9][0-9]*)/?\Z"
+)
+JIRA_KEY_RE = re.compile(r"\bROCM-[0-9]+\b", re.IGNORECASE)
+
+
+class ApiError(RuntimeError):
+    def __init__(self, status: int, message: str):
+        super().__init__(f"API request failed with HTTP {status}: {message}")
+        self.status = status
+        self.message = message
+
+
+class Transport(Protocol):
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        body: bytes | None = None,
+    ) -> Any: ...
+
+
+class UrlLibTransport:
+    """urllib-backed JSON transport with bounded requests."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        body: bytes | None = None,
+    ) -> Any:
+        request = urllib.request.Request(
+            url=url,
+            method=method,
+            headers=headers or {},
+            data=body,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = response.read()
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            raise ApiError(exc.code, detail) from exc
+        except urllib.error.URLError as exc:
+            raise ApiError(0, str(exc.reason)) from exc
+        if not payload:
+            return None
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ApiError(0, "response was not valid JSON") from exc
+
+
+def parse_pull_request_url(url: str) -> tuple[str, str, int]:
+    match = PR_URL_RE.fullmatch(url)
+    if match is None:
+        raise ValueError(f"not a canonical GitHub pull request URL: {url!r}")
+    return match.group(1), match.group(2), int(match.group(3))
+
+
+def extract_jira_keys(text: str) -> list[str]:
+    """Return unique ROCm Jira keys in first-appearance order."""
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in JIRA_KEY_RE.finditer(text):
+        key = match.group(0).upper()
+        if key not in seen:
+            seen.add(key)
+            result.append(key)
+    return result
+
+
+@dataclass
+class GitHubClient:
+    token: str
+    transport: Transport = UrlLibTransport()
+    api_url: str = "https://api.github.com"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+    ) -> Any:
+        headers = {
+            "Accept": GITHUB_ACCEPT,
+            "Authorization": f"Bearer {self.token}",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            "User-Agent": "rocm-rockrel-express-train",
+        }
+        payload = None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            payload = json.dumps(body, separators=(",", ":")).encode()
+        return self.transport.request(
+            method,
+            f"{self.api_url.rstrip('/')}{path}",
+            headers=headers,
+            body=payload,
+        )
+
+    def pull(self, owner: str, repo: str, number: int) -> dict[str, Any]:
+        return self._request("GET", f"/repos/{owner}/{repo}/pulls/{number}")
+
+    def label_actor(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        label: str,
+    ) -> str | None:
+        matches: list[str] = []
+        page = 1
+        while True:
+            events = self._request(
+                "GET",
+                f"/repos/{owner}/{repo}/issues/{number}/timeline?per_page=100&page={page}",
+            )
+            if not isinstance(events, list):
+                raise ApiError(0, "GitHub timeline response was not an array")
+            for event in events:
+                if (
+                    event.get("event") == "labeled"
+                    and event.get("label", {}).get("name") == label
+                    and isinstance(event.get("actor", {}).get("login"), str)
+                ):
+                    matches.append(event["actor"]["login"])
+            if len(events) < 100:
+                break
+            page += 1
+        return matches[-1] if matches else None
+
+    def permission(self, owner: str, repo: str, username: str) -> str:
+        encoded = urllib.parse.quote(username, safe="")
+        response = self._request(
+            "GET", f"/repos/{owner}/{repo}/collaborators/{encoded}/permission"
+        )
+        permission = response.get("permission")
+        if not isinstance(permission, str):
+            raise ApiError(0, "GitHub permission response omitted permission")
+        return permission
+
+    def branch(self, owner: str, repo: str, branch: str) -> dict[str, Any]:
+        encoded = urllib.parse.quote(branch, safe="")
+        try:
+            response = self._request("GET", f"/repos/{owner}/{repo}/branches/{encoded}")
+        except ApiError as exc:
+            if exc.status == 404:
+                return {"exists": False, "protected": False, "sha": None}
+            raise
+        return {
+            "exists": True,
+            "protected": response.get("protected") is True,
+            "sha": response.get("commit", {}).get("sha"),
+        }
+
+    def pulls(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        base: str,
+        state: str = "all",
+    ) -> list[dict[str, Any]]:
+        query = urllib.parse.urlencode(
+            {"state": state, "base": base, "per_page": 100, "sort": "updated"}
+        )
+        response = self._request("GET", f"/repos/{owner}/{repo}/pulls?{query}")
+        if not isinstance(response, list):
+            raise ApiError(0, "GitHub pulls response was not an array")
+        return response
+
+    def remove_label(
+        self, owner: str, repo: str, number: int, label: str
+    ) -> None:
+        encoded = urllib.parse.quote(label, safe="")
+        try:
+            self._request(
+                "DELETE", f"/repos/{owner}/{repo}/issues/{number}/labels/{encoded}"
+            )
+        except ApiError as exc:
+            if exc.status != 404:
+                raise
+
+    def issue_comments(self, owner: str, repo: str, number: int) -> list[dict[str, Any]]:
+        response = self._request(
+            "GET", f"/repos/{owner}/{repo}/issues/{number}/comments?per_page=100"
+        )
+        if not isinstance(response, list):
+            raise ApiError(0, "GitHub comments response was not an array")
+        return response
+
+    def upsert_comment(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        *,
+        marker: str,
+        body: str,
+    ) -> None:
+        marked_body = f"{marker}\n{body}"
+        for comment in self.issue_comments(owner, repo, number):
+            if marker in (comment.get("body") or ""):
+                self._request(
+                    "PATCH",
+                    f"/repos/{owner}/{repo}/issues/comments/{comment['id']}",
+                    body={"body": marked_body},
+                )
+                return
+        self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/issues/{number}/comments",
+            body={"body": marked_body},
+        )
+
+    def create_pull(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        title: str,
+        body: str,
+        head: str,
+        base: str,
+    ) -> str:
+        response = self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/pulls",
+            body={
+                "title": title,
+                "body": body,
+                "head": head,
+                "base": base,
+                "draft": True,
+            },
+        )
+        url = response.get("html_url")
+        if not isinstance(url, str):
+            raise ApiError(0, "created pull request response omitted html_url")
+        return url
+
+    def ensure_label(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        name: str,
+        description: str,
+        color: str = "7B42BC",
+    ) -> None:
+        encoded = urllib.parse.quote(name, safe="")
+        payload = {"new_name": name, "description": description, "color": color}
+        try:
+            self._request("PATCH", f"/repos/{owner}/{repo}/labels/{encoded}", body=payload)
+        except ApiError as exc:
+            if exc.status != 404:
+                raise
+            self._request(
+                "POST",
+                f"/repos/{owner}/{repo}/labels",
+                body={"name": name, "description": description, "color": color},
+            )
+
+
+@dataclass
+class JiraClient:
+    base_url: str
+    token: str
+    transport: Transport = UrlLibTransport()
+
+    def fix_versions(self, issue_key: str) -> set[str]:
+        encoded = urllib.parse.quote(issue_key, safe="")
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.token}",
+            "User-Agent": "rocm-rockrel-express-train",
+        }
+        response = self.transport.request(
+            "GET",
+            f"{self.base_url.rstrip('/')}/rest/api/2/issue/{encoded}?fields=fixVersions",
+            headers=headers,
+            body=None,
+        )
+        versions = response.get("fields", {}).get("fixVersions", [])
+        if not isinstance(versions, list):
+            raise ApiError(0, "Jira fixVersions response was not an array")
+        return {
+            item["name"]
+            for item in versions
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }

--- a/scripts/express_train/clients.py
+++ b/scripts/express_train/clients.py
@@ -217,6 +217,34 @@ class GitHubClient:
             and isinstance(item.get("html_url"), str)
         ]
 
+    def commit(
+        self, owner: str, repo: str, sha: str
+    ) -> dict[str, Any]:
+        encoded = urllib.parse.quote(sha, safe="")
+        response = self._request(
+            "GET", f"/repos/{owner}/{repo}/commits/{encoded}"
+        )
+        if not isinstance(response, dict):
+            raise ApiError(0, "GitHub commit response was not an object")
+        return response
+
+    def compare(
+        self,
+        owner: str,
+        repo: str,
+        base: str,
+        head: str,
+    ) -> dict[str, Any]:
+        encoded_base = urllib.parse.quote(base, safe="")
+        encoded_head = urllib.parse.quote(head, safe="")
+        response = self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/compare/{encoded_base}...{encoded_head}",
+        )
+        if not isinstance(response, dict):
+            raise ApiError(0, "GitHub compare response was not an object")
+        return response
+
     def remove_label(
         self, owner: str, repo: str, number: int, label: str
     ) -> None:

--- a/scripts/express_train/clients.py
+++ b/scripts/express_train/clients.py
@@ -191,6 +191,32 @@ class GitHubClient:
             raise ApiError(0, "GitHub pulls response was not an array")
         return response
 
+    def search_merged_labeled_pull_requests(
+        self,
+        owner: str,
+        repo: str,
+        label: str,
+    ) -> list[str]:
+        query = urllib.parse.urlencode(
+            {
+                "q": (
+                    f'repo:{owner}/{repo} is:pr is:merged label:"{label}"'
+                ),
+                "per_page": 100,
+            }
+        )
+        response = self._request("GET", f"/search/issues?{query}")
+        items = response.get("items", [])
+        if not isinstance(items, list):
+            raise ApiError(0, "GitHub search response omitted its items array")
+        return [
+            item["html_url"]
+            for item in items
+            if isinstance(item, dict)
+            and isinstance(item.get("pull_request"), dict)
+            and isinstance(item.get("html_url"), str)
+        ]
+
     def remove_label(
         self, owner: str, repo: str, number: int, label: str
     ) -> None:

--- a/scripts/express_train/config.py
+++ b/scripts/express_train/config.py
@@ -1,0 +1,136 @@
+"""Load and validate version-controlled Express Train configuration."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_REPOSITORIES = frozenset(
+    {"ROCm/TheRock", "ROCm/rocm-systems", "ROCm/rocm-libraries"}
+)
+VALID_STATES = frozenset({"active", "inactive"})
+VALID_MODES = frozenset({"disabled", "validate", "shadow", "create-draft"})
+TRAIN_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
+LABEL_PREFIX = "express-train:"
+
+
+class ConfigError(ValueError):
+    """The train configuration is invalid and must not be used."""
+
+
+@dataclass(frozen=True)
+class RepositoryConfig:
+    source_branch: str
+    target_branch: str
+
+
+@dataclass(frozen=True)
+class TrainConfig:
+    id: str
+    jira_fix_version: str
+    state: str
+    mode: str
+    repositories: dict[str, RepositoryConfig]
+
+    @property
+    def label(self) -> str:
+        return f"{LABEL_PREFIX}{self.id}"
+
+
+@dataclass(frozen=True)
+class ExpressTrainConfig:
+    trains: dict[str, TrainConfig]
+
+    def train(self, train_id: str) -> TrainConfig:
+        try:
+            return self.trains[train_id]
+        except KeyError as exc:
+            raise ConfigError(f"unknown train id: {train_id}") from exc
+
+
+def _required_string(value: dict[str, Any], key: str, context: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item.strip():
+        raise ConfigError(f"{context}.{key} must be a non-empty string")
+    return item
+
+
+def _parse_repository(name: str, raw: Any, context: str) -> RepositoryConfig:
+    if name not in SUPPORTED_REPOSITORIES:
+        raise ConfigError(f"unsupported repository: {name}")
+    if not isinstance(raw, dict):
+        raise ConfigError(f"{context} must be an object")
+    source = _required_string(raw, "source_branch", context)
+    target = _required_string(raw, "target_branch", context)
+    expected_source = "main" if name == "ROCm/TheRock" else "develop"
+    if source != expected_source:
+        raise ConfigError(
+            f"{context}.source_branch must be {expected_source!r}, got {source!r}"
+        )
+    if not target.startswith("release/"):
+        raise ConfigError(f"{context}.target_branch must start with release/")
+    return RepositoryConfig(source_branch=source, target_branch=target)
+
+
+def _parse_train(raw: Any, index: int) -> TrainConfig:
+    context = f"trains[{index}]"
+    if not isinstance(raw, dict):
+        raise ConfigError(f"{context} must be an object")
+    train_id = _required_string(raw, "id", context)
+    if TRAIN_ID_RE.fullmatch(train_id) is None:
+        raise ConfigError(f"{context}.id is invalid: {train_id!r}")
+    jira_fix_version = _required_string(raw, "jira_fix_version", context)
+    state = _required_string(raw, "state", context)
+    mode = _required_string(raw, "mode", context)
+    if state not in VALID_STATES:
+        raise ConfigError(f"{context}.state must be one of {sorted(VALID_STATES)}")
+    if mode not in VALID_MODES:
+        raise ConfigError(f"{context}.mode must be one of {sorted(VALID_MODES)}")
+    raw_repositories = raw.get("repositories")
+    if not isinstance(raw_repositories, dict) or not raw_repositories:
+        raise ConfigError(f"{context}.repositories must be a non-empty object")
+    repositories = {
+        name: _parse_repository(name, value, f"{context}.repositories[{name!r}]")
+        for name, value in raw_repositories.items()
+    }
+    return TrainConfig(
+        id=train_id,
+        jira_fix_version=jira_fix_version,
+        state=state,
+        mode=mode,
+        repositories=repositories,
+    )
+
+
+def load_config(path: str | Path) -> ExpressTrainConfig:
+    """Read *path*, validate all fields, and return immutable train objects."""
+
+    try:
+        raw = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"cannot load train configuration: {exc}") from exc
+    if not isinstance(raw, dict) or raw.get("schema_version") != 1:
+        raise ConfigError("schema_version must be 1")
+    raw_trains = raw.get("trains")
+    if not isinstance(raw_trains, list):
+        raise ConfigError("trains must be an array")
+    trains: dict[str, TrainConfig] = {}
+    for index, raw_train in enumerate(raw_trains):
+        train = _parse_train(raw_train, index)
+        if train.id in trains:
+            raise ConfigError(f"duplicate train id: {train.id}")
+        trains[train.id] = train
+    return ExpressTrainConfig(trains=trains)
+
+
+def parse_train_label(label: str) -> str | None:
+    """Return the train ID encoded by a valid Express Train label."""
+
+    if not label.startswith(LABEL_PREFIX):
+        return None
+    train_id = label.removeprefix(LABEL_PREFIX)
+    return train_id if TRAIN_ID_RE.fullmatch(train_id) else None

--- a/scripts/express_train/coverage.py
+++ b/scripts/express_train/coverage.py
@@ -1,0 +1,213 @@
+"""Prove when an existing target pull request covers a source change."""
+
+from __future__ import annotations
+
+import configparser
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .clients import GitHubClient
+from .git import evaluate_cherry_pick
+from .models import Status
+
+
+CHERRY_PICK_ORIGIN_RE = re.compile(
+    r"^\(cherry picked from commit ([0-9a-f]{40})\)$", re.MULTILINE
+)
+GITHUB_REPO_RE = re.compile(
+    r"(?:https://github\.com/|git@github\.com:)([^/]+)/([^/]+?)(?:\.git)?\Z"
+)
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def extract_cherry_pick_origin(message: str) -> str | None:
+    """Extract Git's full original-commit trailer from a commit message."""
+
+    match = CHERRY_PICK_ORIGIN_RE.search(message)
+    return match.group(1) if match else None
+
+
+def _ensure_commit(repo: Path, sha: str) -> bool:
+    if _run(repo, "cat-file", "-e", f"{sha}^{{commit}}").returncode == 0:
+        return True
+    fetch = _run(repo, "fetch", "--no-tags", "origin", sha)
+    return fetch.returncode == 0 and _run(
+        repo, "cat-file", "-e", f"{sha}^{{commit}}"
+    ).returncode == 0
+
+
+def _gitlink_changes(repo: Path, source: str) -> list[dict[str, str]]:
+    parents = _run(repo, "rev-list", "--parents", "-n", "1", source)
+    fields = parents.stdout.split()
+    if parents.returncode != 0 or len(fields) < 2:
+        return []
+    raw = _run(
+        repo,
+        "diff-tree",
+        "--raw",
+        "--no-commit-id",
+        "-r",
+        fields[1],
+        source,
+    )
+    changes = []
+    for line in raw.stdout.splitlines():
+        metadata, separator, path = line.partition("\t")
+        parts = metadata.split()
+        if not separator or len(parts) < 5:
+            continue
+        old_mode = parts[0].removeprefix(":")
+        new_mode = parts[1]
+        if old_mode == "160000" and new_mode == "160000":
+            changes.append(
+                {
+                    "path": path,
+                    "old": parts[2],
+                    "desired": parts[3],
+                }
+            )
+    return changes
+
+
+def _changed_paths(repo: Path, source: str) -> set[str]:
+    result = _run(
+        repo,
+        "diff-tree",
+        "--no-commit-id",
+        "--name-only",
+        "-r",
+        f"{source}^",
+        source,
+    )
+    return {line for line in result.stdout.splitlines() if line}
+
+
+def _gitlink_pin(repo: Path, revision: str, path: str) -> str | None:
+    result = _run(repo, "ls-tree", revision, "--", path)
+    fields = result.stdout.split()
+    if result.returncode != 0 or len(fields) < 3 or fields[0] != "160000":
+        return None
+    return fields[2]
+
+
+def _submodule_repositories(repo: Path, revision: str) -> dict[str, tuple[str, str]]:
+    result = _run(repo, "show", f"{revision}:.gitmodules")
+    if result.returncode != 0:
+        return {}
+    parser = configparser.ConfigParser()
+    parser.read_string(result.stdout)
+    repositories: dict[str, tuple[str, str]] = {}
+    for section in parser.sections():
+        if not parser.has_option(section, "path") or not parser.has_option(
+            section, "url"
+        ):
+            continue
+        match = GITHUB_REPO_RE.fullmatch(parser.get(section, "url"))
+        if match:
+            repositories[parser.get(section, "path")] = (
+                match.group(1),
+                match.group(2),
+            )
+    return repositories
+
+
+def _commit_message(commit: dict[str, Any]) -> str:
+    value = commit.get("commit", {}).get("message")
+    return value if isinstance(value, str) else ""
+
+
+def find_covering_pull(
+    repo: str | Path,
+    github: GitHubClient,
+    source_sha: str,
+    candidate: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Return positive coverage evidence for an open target PR, otherwise None."""
+
+    if str(candidate.get("state", "")).lower() != "open":
+        return None
+    candidate_sha = candidate.get("head", {}).get("sha")
+    candidate_url = candidate.get("html_url")
+    if not isinstance(candidate_sha, str) or not isinstance(candidate_url, str):
+        return None
+    repo_path = Path(repo)
+    if not _ensure_commit(repo_path, source_sha) or not _ensure_commit(
+        repo_path, candidate_sha
+    ):
+        return None
+
+    gitlinks = _gitlink_changes(repo_path, source_sha)
+    gitlink_paths = {item["path"] for item in gitlinks}
+    if gitlinks and _changed_paths(repo_path, source_sha) == gitlink_paths:
+        submodules = _submodule_repositories(repo_path, source_sha)
+        evidence = []
+        for change in gitlinks:
+            path = change["path"]
+            desired = change["desired"]
+            candidate_pin = _gitlink_pin(repo_path, candidate_sha, path)
+            component = submodules.get(path)
+            if candidate_pin is None or component is None:
+                return None
+            if desired == candidate_pin:
+                evidence.append(
+                    {"path": path, "desired": desired, "candidate": candidate_pin}
+                )
+                continue
+            owner, component_repo = component
+            comparison = github.compare(
+                owner, component_repo, desired, candidate_pin
+            )
+            if comparison.get("status") in {"ahead", "identical"}:
+                evidence.append(
+                    {"path": path, "desired": desired, "candidate": candidate_pin}
+                )
+                continue
+            desired_commit = github.commit(owner, component_repo, desired)
+            desired_origin = extract_cherry_pick_origin(
+                _commit_message(desired_commit)
+            )
+            candidate_origins = {
+                origin
+                for item in comparison.get("commits", [])
+                if isinstance(item, dict)
+                for origin in [extract_cherry_pick_origin(_commit_message(item))]
+                if origin is not None
+            }
+            if desired_origin is None or desired_origin not in candidate_origins:
+                return None
+            evidence.append(
+                {
+                    "path": path,
+                    "desired": desired,
+                    "candidate": candidate_pin,
+                    "common_origin": desired_origin,
+                }
+            )
+        return {
+            "reason": "gitlink_cherry_pick_provenance",
+            "paths": sorted(gitlink_paths),
+            "pull_request_url": candidate_url,
+            "gitlinks": evidence,
+        }
+
+    ordinary = evaluate_cherry_pick(repo_path, source_sha, candidate_sha)
+    if ordinary.status is Status.ALREADY_CONTAINED:
+        return {
+            "reason": ordinary.reason_code,
+            "paths": sorted(_changed_paths(repo_path, source_sha)),
+            "pull_request_url": candidate_url,
+            "git": ordinary.evidence,
+        }
+    return None

--- a/scripts/express_train/git.py
+++ b/scripts/express_train/git.py
@@ -1,0 +1,235 @@
+"""Side-effect-contained Git planning for Express Train requests."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from .models import Result, Status
+
+
+def _run(
+    repo: Path,
+    *args: str,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _resolve(repo: Path, revision: str) -> str | None:
+    result = _run(repo, "rev-parse", "--verify", f"{revision}^{{commit}}")
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool | None:
+    result = _run(repo, "merge-base", "--is-ancestor", ancestor, descendant)
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _git_result(
+    status: Status,
+    reason_code: str,
+    message: str,
+    *,
+    source: str | None = None,
+    target: str | None = None,
+    extra: dict[str, object] | None = None,
+) -> Result:
+    evidence: dict[str, object] = {
+        "source_commit": source,
+        "target_head": target,
+    }
+    evidence.update(extra or {})
+    return Result(
+        status=status,
+        reason_code=reason_code,
+        message=message,
+        evidence=evidence,
+    )
+
+
+def evaluate_cherry_pick(
+    repo: str | Path,
+    source_revision: str,
+    target_revision: str,
+) -> Result:
+    """Plan an aggregate cherry-pick without changing the caller's checkout."""
+
+    repo_path = Path(repo)
+    source = _resolve(repo_path, source_revision)
+    if source is None:
+        return _git_result(
+            Status.BLOCKED,
+            "source_commit_missing",
+            "The source commit is not available in the repository.",
+        )
+    target = _resolve(repo_path, target_revision)
+    if target is None:
+        return _git_result(
+            Status.BLOCKED,
+            "target_ref_missing",
+            "The target ref is not available in the repository.",
+            source=source,
+        )
+    contained = _is_ancestor(repo_path, source, target)
+    if contained is None:
+        return _git_result(
+            Status.BLOCKED,
+            "ancestry_check_failed",
+            "Git could not establish source-to-target ancestry.",
+            source=source,
+            target=target,
+        )
+    if contained:
+        return _git_result(
+            Status.ALREADY_CONTAINED,
+            "source_ancestor_of_target",
+            "The exact source commit is reachable from the target.",
+            source=source,
+            target=target,
+        )
+
+    parents = _run(repo_path, "rev-list", "--parents", "-n", "1", source)
+    if parents.returncode != 0:
+        return _git_result(
+            Status.BLOCKED,
+            "source_parent_read_failed",
+            "Git could not read the source commit parents.",
+            source=source,
+            target=target,
+        )
+    parent_count = max(0, len(parents.stdout.split()) - 1)
+    mainline = 1 if parent_count > 1 else None
+
+    with tempfile.TemporaryDirectory(prefix="express-train-plan-") as temp_root:
+        worktree = Path(temp_root) / "worktree"
+        add = _run(repo_path, "worktree", "add", "--detach", str(worktree), target)
+        if add.returncode != 0:
+            return _git_result(
+                Status.BLOCKED,
+                "worktree_creation_failed",
+                "Git could not create a disposable target worktree.",
+                source=source,
+                target=target,
+                extra={"stderr": add.stderr.strip()},
+            )
+        try:
+            args = ["cherry-pick", "--no-commit"]
+            if mainline is not None:
+                args.extend(["-m", str(mainline)])
+            args.append(source)
+            trial = _run(worktree, *args)
+            unmerged = _run(worktree, "ls-files", "-u").stdout.strip()
+            status = _run(worktree, "status", "--porcelain").stdout.strip()
+            if trial.returncode != 0 and unmerged:
+                return _git_result(
+                    Status.MANUAL_RESOLUTION_REQUIRED,
+                    "cherry_pick_conflict",
+                    "The aggregate cherry-pick conflicts with the target.",
+                    source=source,
+                    target=target,
+                    extra={"mainline": mainline, "conflicted": True},
+                )
+            if not status:
+                return _git_result(
+                    Status.ALREADY_CONTAINED,
+                    "empty_trial_application",
+                    "Applying the aggregate source change produces an empty tree change.",
+                    source=source,
+                    target=target,
+                    extra={"mainline": mainline, "patch_equivalent": True},
+                )
+            if trial.returncode != 0:
+                return _git_result(
+                    Status.BLOCKED,
+                    "trial_application_failed",
+                    "The trial cherry-pick failed without a classifiable conflict.",
+                    source=source,
+                    target=target,
+                    extra={
+                        "mainline": mainline,
+                        "stderr": trial.stderr.strip(),
+                    },
+                )
+            return _git_result(
+                Status.CHERRY_PICK_REQUIRED,
+                "clean_trial_application",
+                "The aggregate source change applies cleanly and is non-empty.",
+                source=source,
+                target=target,
+                extra={"mainline": mainline, "patch_equivalent": False},
+            )
+        finally:
+            _run(repo_path, "worktree", "remove", "--force", str(worktree))
+
+
+def classify_gitlink(
+    component_repo: str | Path,
+    desired_revision: str,
+    target_revision: str,
+) -> Result:
+    """Classify the directional relationship between desired and target pins."""
+
+    repo_path = Path(component_repo)
+    desired = _resolve(repo_path, desired_revision)
+    target = _resolve(repo_path, target_revision)
+    evidence = {
+        "source_desired_pin": desired,
+        "target_current_pin": target,
+    }
+    if desired is None or target is None:
+        return Result(
+            status=Status.BLOCKED,
+            reason_code="gitlink_object_missing",
+            message="One or both gitlink commits are unavailable.",
+            evidence=evidence,
+        )
+    if desired == target:
+        return Result(
+            status=Status.ALREADY_CONTAINED,
+            reason_code="gitlink_pins_equal",
+            message="The target already uses the desired component pin.",
+            evidence=evidence,
+        )
+    target_contains_desired = _is_ancestor(repo_path, desired, target)
+    desired_contains_target = _is_ancestor(repo_path, target, desired)
+    if target_contains_desired is None or desired_contains_target is None:
+        return Result(
+            status=Status.BLOCKED,
+            reason_code="gitlink_ancestry_unknown",
+            message="Git could not establish the gitlink ancestry direction.",
+            evidence=evidence,
+        )
+    if target_contains_desired:
+        return Result(
+            status=Status.ALREADY_CONTAINED,
+            reason_code="target_pin_contains_desired",
+            message="The target component pin descends from the desired pin.",
+            evidence=evidence,
+        )
+    if desired_contains_target:
+        return Result(
+            status=Status.CHERRY_PICK_REQUIRED,
+            reason_code="desired_pin_ahead_of_target",
+            message="The desired component pin descends from the target pin.",
+            evidence=evidence,
+        )
+    return Result(
+        status=Status.MANUAL_RESOLUTION_REQUIRED,
+        reason_code="gitlink_histories_diverged",
+        message="Desired and target component pins have diverged.",
+        evidence=evidence,
+    )

--- a/scripts/express_train/models.py
+++ b/scripts/express_train/models.py
@@ -1,0 +1,38 @@
+"""Shared immutable data models for Express Train automation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class Status(StrEnum):
+    WAITING_FOR_MERGE = "waiting_for_merge"
+    INVALID = "invalid"
+    BLOCKED = "blocked"
+    ALREADY_CONTAINED = "already_contained"
+    COVERED_BY_EXISTING_PR = "covered_by_existing_pr"
+    CHERRY_PICK_REQUIRED = "cherry_pick_required"
+    DRAFT_CREATED = "draft_created"
+    MANUAL_RESOLUTION_REQUIRED = "manual_resolution_required"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class Result:
+    """Machine-readable outcome emitted by every command."""
+
+    status: Status
+    reason_code: str
+    message: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+    source_pr: str | None = None
+    train_id: str | None = None
+    target_branch: str | None = None
+    pull_request_url: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["status"] = self.status.value
+        return value

--- a/scripts/express_train/orchestrator.py
+++ b/scripts/express_train/orchestrator.py
@@ -1,0 +1,249 @@
+"""Orchestrate one source pull request and one Express Train."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .clients import GitHubClient, JiraClient, extract_jira_keys, parse_pull_request_url
+from .config import ExpressTrainConfig
+from .git import evaluate_cherry_pick
+from .models import Result, Status
+from .policy import QualificationFacts, qualify_request
+
+
+def automation_branch(train_id: str, source_number: int) -> str:
+    return f"shared/cherry-pick/{train_id}/{source_number}"
+
+
+def identity_marker(repository: str, source_number: int, train_id: str) -> str:
+    return f"<!-- express-train:{repository}#{source_number}:{train_id} -->"
+
+
+def status_marker(train_id: str) -> str:
+    return f"<!-- express-train-status:{train_id} -->"
+
+
+def render_pull_body(
+    *,
+    marker: str,
+    source_url: str,
+    source_sha: str,
+    train_id: str,
+    source_body: str,
+) -> str:
+    return (
+        f"{marker}\n"
+        f"Cherry-picks [`{source_sha}`]({source_url}/commits/{source_sha}) from "
+        f"{source_url} for Express Train `{train_id}`.\n\n"
+        "This pull request was created as a draft and remains a draft until an "
+        "operator completes target-branch review. The automation never marks it "
+        "ready or merges it.\n\n"
+        "## Source pull request\n\n"
+        f"{source_body.strip() or '_No source description was provided._'}\n"
+    )
+
+
+def render_status_comment(result: Result) -> str:
+    lines = [
+        "## Express Train cherry-pick status",
+        "",
+        f"- Train: `{result.train_id}`",
+        f"- Status: `{result.status.value}`",
+        f"- Reason: `{result.reason_code}`",
+        f"- Target: `{result.target_branch}`",
+    ]
+    if result.pull_request_url:
+        lines.append(f"- Pull request: {result.pull_request_url}")
+    lines.extend(["", result.message])
+    return "\n".join(lines)
+
+
+class Planner:
+    """Gather external facts and produce one deterministic request plan."""
+
+    def __init__(
+        self,
+        config: ExpressTrainConfig,
+        github: GitHubClient,
+        jira: JiraClient,
+        *,
+        evaluator: Callable[[Path, str, str], Result] = evaluate_cherry_pick,
+    ) -> None:
+        self.config = config
+        self.github = github
+        self.jira = jira
+        self.evaluator = evaluator
+
+    @staticmethod
+    def _with_context(
+        result: Result,
+        *,
+        source_url: str,
+        train_id: str,
+        target_branch: str | None,
+        evidence: dict[str, Any] | None = None,
+        pull_request_url: str | None = None,
+    ) -> Result:
+        combined = dict(result.evidence)
+        combined.update(evidence or {})
+        return Result(
+            status=result.status,
+            reason_code=result.reason_code,
+            message=result.message,
+            evidence=combined,
+            source_pr=source_url,
+            train_id=train_id,
+            target_branch=target_branch,
+            pull_request_url=pull_request_url or result.pull_request_url,
+        )
+
+    def plan(
+        self,
+        source_url: str,
+        train_id: str,
+        repo_dir: str | Path,
+    ) -> Result:
+        owner, repo, number = parse_pull_request_url(source_url)
+        repository = f"{owner}/{repo}"
+        train = self.config.train(train_id)
+        repository_config = train.repositories.get(repository)
+        target_branch = (
+            repository_config.target_branch if repository_config else None
+        )
+        pull = self.github.pull(owner, repo, number)
+        current_labels = {
+            item.get("name")
+            for item in pull.get("labels", [])
+            if isinstance(item, dict)
+        }
+        if train.label not in current_labels:
+            return Result(
+                status=Status.INVALID,
+                reason_code="train_label_missing",
+                message=f"The source PR does not currently have label {train.label}.",
+                source_pr=source_url,
+                train_id=train_id,
+                target_branch=target_branch,
+            )
+
+        errors: list[str] = []
+        label_actor: str | None = None
+        permission = "none"
+        branch = {"exists": False, "protected": False, "sha": None}
+        jira_keys = extract_jira_keys(
+            f"{pull.get('title') or ''}\n{pull.get('body') or ''}"
+        )
+        fix_versions: set[str] = set()
+        try:
+            label_actor = self.github.label_actor(
+                owner, repo, number, train.label
+            )
+            if label_actor is not None:
+                permission = self.github.permission(owner, repo, label_actor)
+        except Exception as exc:  # external evidence is fail-closed
+            errors.append(f"github_label_evidence:{type(exc).__name__}")
+        if label_actor is None and not errors:
+            permission = "none"
+        if repository_config is not None:
+            try:
+                branch = self.github.branch(
+                    owner, repo, repository_config.target_branch
+                )
+            except Exception as exc:
+                errors.append(f"github_target_evidence:{type(exc).__name__}")
+        if not jira_keys:
+            fix_versions = set()
+        else:
+            for key in jira_keys:
+                try:
+                    fix_versions.update(self.jira.fix_versions(key))
+                except Exception as exc:
+                    errors.append(f"jira_evidence:{key}:{type(exc).__name__}")
+
+        facts = QualificationFacts(
+            source_pr=source_url,
+            repository=repository,
+            base_branch=pull.get("base", {}).get("ref") or "",
+            merged=pull.get("merged") is True,
+            closed=pull.get("state") == "closed",
+            label_actor_permission=permission,
+            jira_fix_versions=frozenset(fix_versions),
+            target_exists=branch["exists"] is True,
+            target_protected=branch["protected"] is True,
+            evidence_errors=tuple(errors),
+        )
+        qualified = qualify_request(train, facts)
+        base_evidence = {
+            "source_title": pull.get("title") or "",
+            "source_body": pull.get("body") or "",
+            "source_number": number,
+            "source_repository": repository,
+            "source_merge_commit": pull.get("merge_commit_sha"),
+            "label_actor": label_actor,
+            "jira_keys": jira_keys,
+            "target_head": branch.get("sha"),
+            "train_mode": train.mode,
+        }
+        qualified = self._with_context(
+            qualified,
+            source_url=source_url,
+            train_id=train_id,
+            target_branch=target_branch,
+            evidence=base_evidence,
+        )
+        if qualified.status is not Status.CHERRY_PICK_REQUIRED:
+            return qualified
+        if not isinstance(pull.get("merge_commit_sha"), str):
+            return Result(
+                status=Status.BLOCKED,
+                reason_code="merge_commit_missing",
+                message="The merged source PR has no aggregate merge commit SHA.",
+                evidence=base_evidence,
+                source_pr=source_url,
+                train_id=train_id,
+                target_branch=target_branch,
+            )
+
+        marker = identity_marker(repository, number, train_id)
+        branch_name = automation_branch(train_id, number)
+        try:
+            target_pulls = self.github.pulls(
+                owner, repo, base=repository_config.target_branch, state="all"
+            )
+        except Exception as exc:
+            return Result(
+                status=Status.BLOCKED,
+                reason_code="existing_pr_evidence_unavailable",
+                message="GitHub could not enumerate existing target pull requests.",
+                evidence={**base_evidence, "error": type(exc).__name__},
+                source_pr=source_url,
+                train_id=train_id,
+                target_branch=target_branch,
+            )
+        for candidate in target_pulls:
+            if marker in (candidate.get("body") or "") or (
+                candidate.get("head", {}).get("ref") == branch_name
+            ):
+                return Result(
+                    status=Status.COVERED_BY_EXISTING_PR,
+                    reason_code="existing_identity_match",
+                    message="An existing target pull request owns this source/train identity.",
+                    evidence=base_evidence,
+                    source_pr=source_url,
+                    train_id=train_id,
+                    target_branch=target_branch,
+                    pull_request_url=candidate.get("html_url"),
+                )
+
+        git_result = self.evaluator(
+            Path(repo_dir), pull["merge_commit_sha"], branch["sha"]
+        )
+        return self._with_context(
+            git_result,
+            source_url=source_url,
+            train_id=train_id,
+            target_branch=target_branch,
+            evidence=base_evidence,
+        )

--- a/scripts/express_train/orchestrator.py
+++ b/scripts/express_train/orchestrator.py
@@ -104,6 +104,8 @@ class Planner:
         source_url: str,
         train_id: str,
         repo_dir: str | Path,
+        *,
+        event_action: str | None = None,
     ) -> Result:
         owner, repo, number = parse_pull_request_url(source_url)
         repository = f"{owner}/{repo}"
@@ -113,6 +115,20 @@ class Planner:
             repository_config.target_branch if repository_config else None
         )
         pull = self.github.pull(owner, repo, number)
+        if event_action == "unlabeled":
+            return Result(
+                status=Status.CANCELLED,
+                reason_code="train_label_removed",
+                message="The Express Train request label was removed.",
+                source_pr=source_url,
+                train_id=train_id,
+                target_branch=target_branch,
+                evidence={
+                    "source_number": number,
+                    "source_repository": repository,
+                    "event_action": event_action,
+                },
+            )
         current_labels = {
             item.get("name")
             for item in pull.get("labels", [])
@@ -185,6 +201,7 @@ class Planner:
             "jira_keys": jira_keys,
             "target_head": branch.get("sha"),
             "train_mode": train.mode,
+            "event_action": event_action,
         }
         qualified = self._with_context(
             qualified,

--- a/scripts/express_train/orchestrator.py
+++ b/scripts/express_train/orchestrator.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from .clients import GitHubClient, JiraClient, extract_jira_keys, parse_pull_request_url
 from .config import ExpressTrainConfig
+from .coverage import find_covering_pull
 from .git import evaluate_cherry_pick
 from .models import Result, Status
 from .policy import QualificationFacts, qualify_request
@@ -70,11 +71,15 @@ class Planner:
         jira: JiraClient,
         *,
         evaluator: Callable[[Path, str, str], Result] = evaluate_cherry_pick,
+        coverage_evaluator: Callable[
+            [Path, GitHubClient, str, dict[str, Any]], dict[str, Any] | None
+        ] = find_covering_pull,
     ) -> None:
         self.config = config
         self.github = github
         self.jira = jira
         self.evaluator = evaluator
+        self.coverage_evaluator = coverage_evaluator
 
     @staticmethod
     def _with_context(
@@ -252,6 +257,38 @@ class Planner:
                     train_id=train_id,
                     target_branch=target_branch,
                     pull_request_url=candidate.get("html_url"),
+                )
+            try:
+                coverage = self.coverage_evaluator(
+                    Path(repo_dir),
+                    self.github,
+                    pull["merge_commit_sha"],
+                    candidate,
+                )
+            except Exception as exc:
+                return Result(
+                    status=Status.BLOCKED,
+                    reason_code="covering_pr_evidence_unavailable",
+                    message="Coverage evaluation for an existing target PR failed.",
+                    evidence={
+                        **base_evidence,
+                        "candidate_pull_request": candidate.get("html_url"),
+                        "error": type(exc).__name__,
+                    },
+                    source_pr=source_url,
+                    train_id=train_id,
+                    target_branch=target_branch,
+                )
+            if coverage is not None:
+                return Result(
+                    status=Status.COVERED_BY_EXISTING_PR,
+                    reason_code=str(coverage["reason"]),
+                    message="An existing target pull request positively covers this change.",
+                    evidence={**base_evidence, "coverage": coverage},
+                    source_pr=source_url,
+                    train_id=train_id,
+                    target_branch=target_branch,
+                    pull_request_url=str(coverage["pull_request_url"]),
                 )
 
         git_result = self.evaluator(

--- a/scripts/express_train/policy.py
+++ b/scripts/express_train/policy.py
@@ -1,0 +1,143 @@
+"""Pure qualification policy for label-triggered cherry-pick requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .config import TrainConfig
+from .models import Result, Status
+
+
+AUTHORIZED_PERMISSIONS = frozenset({"write", "maintain", "admin"})
+
+
+@dataclass(frozen=True)
+class QualificationFacts:
+    source_pr: str
+    repository: str
+    base_branch: str
+    merged: bool
+    closed: bool
+    label_actor_permission: str
+    jira_fix_versions: frozenset[str]
+    target_exists: bool
+    target_protected: bool
+    evidence_errors: tuple[str, ...] = ()
+
+
+def _result(
+    status: Status,
+    reason_code: str,
+    message: str,
+    train: TrainConfig,
+    facts: QualificationFacts,
+) -> Result:
+    repository = train.repositories.get(facts.repository)
+    return Result(
+        status=status,
+        reason_code=reason_code,
+        message=message,
+        source_pr=facts.source_pr,
+        train_id=train.id,
+        target_branch=repository.target_branch if repository else None,
+        evidence={
+            "repository": facts.repository,
+            "base_branch": facts.base_branch,
+            "label_actor_permission": facts.label_actor_permission,
+            "jira_fix_versions": sorted(facts.jira_fix_versions),
+            "evidence_errors": list(facts.evidence_errors),
+        },
+    )
+
+
+def qualify_request(train: TrainConfig, facts: QualificationFacts) -> Result:
+    """Apply deterministic request policy without performing any I/O."""
+
+    if facts.evidence_errors:
+        return _result(
+            Status.BLOCKED,
+            "evidence_unavailable",
+            "Required evidence is temporarily unavailable; the label is retained.",
+            train,
+            facts,
+        )
+    if train.state != "active":
+        return _result(
+            Status.INVALID,
+            "inactive_train",
+            f"Express Train {train.id} is inactive.",
+            train,
+            facts,
+        )
+    repository = train.repositories.get(facts.repository)
+    if repository is None:
+        return _result(
+            Status.INVALID,
+            "repository_not_configured",
+            f"{facts.repository} is not configured for Express Train {train.id}.",
+            train,
+            facts,
+        )
+    if facts.base_branch != repository.source_branch:
+        return _result(
+            Status.INVALID,
+            "source_branch_mismatch",
+            f"Source base must be {repository.source_branch}.",
+            train,
+            facts,
+        )
+    if facts.label_actor_permission not in AUTHORIZED_PERMISSIONS:
+        return _result(
+            Status.INVALID,
+            "label_actor_not_authorized",
+            "The label actor must have write, maintain, or admin permission.",
+            train,
+            facts,
+        )
+    if train.jira_fix_version not in facts.jira_fix_versions:
+        return _result(
+            Status.INVALID,
+            "jira_fix_version_mismatch",
+            f"No referenced ROCm Jira issue has Fix Version {train.jira_fix_version}.",
+            train,
+            facts,
+        )
+    if not facts.target_exists:
+        return _result(
+            Status.INVALID,
+            "target_branch_missing",
+            f"Target branch {repository.target_branch} does not exist.",
+            train,
+            facts,
+        )
+    if not facts.target_protected:
+        return _result(
+            Status.INVALID,
+            "target_branch_not_protected",
+            f"Target branch {repository.target_branch} is not protected by PR rules.",
+            train,
+            facts,
+        )
+    if not facts.merged:
+        if facts.closed:
+            return _result(
+                Status.CANCELLED,
+                "source_closed_without_merge",
+                "The source pull request closed without merging.",
+                train,
+                facts,
+            )
+        return _result(
+            Status.WAITING_FOR_MERGE,
+            "source_not_merged",
+            "The request is valid and will run after the source PR merges.",
+            train,
+            facts,
+        )
+    return _result(
+        Status.CHERRY_PICK_REQUIRED,
+        "qualified_for_planning",
+        "The request qualifies for repository planning.",
+        train,
+        facts,
+    )

--- a/scripts/express_train/writer.py
+++ b/scripts/express_train/writer.py
@@ -1,0 +1,239 @@
+"""The single draft-only write transaction for Express Train automation."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .clients import GitHubClient, parse_pull_request_url
+from .config import TrainConfig
+from .models import Result, Status
+from .orchestrator import automation_branch, identity_marker, render_pull_body
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _remote_head(repo: Path, branch: str) -> str | None:
+    result = _run(repo, "ls-remote", "--heads", "origin", f"refs/heads/{branch}")
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git ls-remote failed")
+    line = result.stdout.strip()
+    return line.split()[0] if line else None
+
+
+def _result_from(
+    plan: Result,
+    status: Status,
+    reason_code: str,
+    message: str,
+    *,
+    evidence: dict[str, Any] | None = None,
+    pull_request_url: str | None = None,
+) -> Result:
+    combined = dict(plan.evidence)
+    combined.update(evidence or {})
+    return Result(
+        status=status,
+        reason_code=reason_code,
+        message=message,
+        evidence=combined,
+        source_pr=plan.source_pr,
+        train_id=plan.train_id,
+        target_branch=plan.target_branch,
+        pull_request_url=pull_request_url,
+    )
+
+
+class DraftWriter:
+    """Create a deterministic branch and draft PR; never make it ready or merge."""
+
+    def __init__(self, github: GitHubClient) -> None:
+        self.github = github
+
+    def create(
+        self,
+        repo_dir: str | Path,
+        train: TrainConfig,
+        plan: Result,
+    ) -> Result:
+        repo = Path(repo_dir)
+        if train.mode != "create-draft":
+            return _result_from(
+                plan,
+                Status.BLOCKED,
+                "write_mode_disabled",
+                f"Train mode {train.mode!r} does not permit draft creation.",
+            )
+        if plan.status is not Status.CHERRY_PICK_REQUIRED:
+            return _result_from(
+                plan,
+                Status.BLOCKED,
+                "plan_not_writable",
+                f"Only cherry_pick_required plans are writable, got {plan.status.value}.",
+            )
+
+        required = (
+            "source_repository",
+            "source_number",
+            "source_title",
+            "source_body",
+            "source_merge_commit",
+            "target_head",
+        )
+        missing = [key for key in required if plan.evidence.get(key) is None]
+        if missing or plan.target_branch is None or plan.train_id is None:
+            return _result_from(
+                plan,
+                Status.BLOCKED,
+                "incomplete_plan",
+                f"The plan is missing required write evidence: {', '.join(missing)}",
+            )
+
+        source_sha = str(plan.evidence["source_merge_commit"])
+        expected_target = str(plan.evidence["target_head"])
+        actual_target = _remote_head(repo, plan.target_branch)
+        if actual_target != expected_target:
+            return _result_from(
+                plan,
+                Status.BLOCKED,
+                "target_head_moved",
+                "The target branch moved after planning; recompute before writing.",
+                evidence={
+                    "expected_target_head": expected_target,
+                    "actual_target_head": actual_target,
+                },
+            )
+
+        source_number = int(plan.evidence["source_number"])
+        branch = automation_branch(plan.train_id, source_number)
+        existing_branch = _remote_head(repo, branch)
+        parent_result = _run(repo, "rev-list", "--parents", "-n", "1", source_sha)
+        if parent_result.returncode != 0:
+            return _result_from(
+                plan,
+                Status.BLOCKED,
+                "source_parent_read_failed",
+                "Git could not read the source commit before writing.",
+            )
+        mainline = 1 if len(parent_result.stdout.split()) - 1 > 1 else None
+
+        with tempfile.TemporaryDirectory(prefix="express-train-write-") as temp_root:
+            worktree = Path(temp_root) / "worktree"
+            add = _run(repo, "worktree", "add", "--detach", str(worktree), expected_target)
+            if add.returncode != 0:
+                return _result_from(
+                    plan,
+                    Status.BLOCKED,
+                    "worktree_creation_failed",
+                    "Git could not create the disposable write worktree.",
+                )
+            try:
+                switch = _run(worktree, "switch", "-c", branch)
+                if switch.returncode != 0:
+                    return _result_from(
+                        plan,
+                        Status.BLOCKED,
+                        "local_branch_creation_failed",
+                        "Git could not create the automation branch.",
+                    )
+                args = ["cherry-pick", "-x"]
+                if mainline is not None:
+                    args.extend(["-m", str(mainline)])
+                args.append(source_sha)
+                cherry_pick = _run(worktree, *args)
+                if cherry_pick.returncode != 0:
+                    unmerged = _run(worktree, "ls-files", "-u").stdout.strip()
+                    status = (
+                        Status.MANUAL_RESOLUTION_REQUIRED if unmerged else Status.BLOCKED
+                    )
+                    reason = (
+                        "cherry_pick_conflict" if unmerged else "cherry_pick_write_failed"
+                    )
+                    return _result_from(
+                        plan,
+                        status,
+                        reason,
+                        "The write cherry-pick conflicted; no branch was pushed."
+                        if unmerged
+                        else "The write cherry-pick failed; no branch was pushed.",
+                    )
+
+                new_head = _run(worktree, "rev-parse", "HEAD").stdout.strip()
+                new_tree = _run(worktree, "rev-parse", "HEAD^{tree}").stdout.strip()
+                reused_branch = False
+                if existing_branch:
+                    fetch = _run(repo, "fetch", "origin", existing_branch)
+                    existing_tree = (
+                        _run(repo, "rev-parse", f"{existing_branch}^{{tree}}").stdout.strip()
+                        if fetch.returncode == 0
+                        else ""
+                    )
+                    if existing_tree != new_tree:
+                        return _result_from(
+                            plan,
+                            Status.BLOCKED,
+                            "automation_branch_mismatch",
+                            "The deterministic remote branch exists with a different tree.",
+                            evidence={"existing_branch_head": existing_branch},
+                        )
+                    reused_branch = True
+                else:
+                    push = _run(
+                        worktree,
+                        "push",
+                        "origin",
+                        f"HEAD:refs/heads/{branch}",
+                        f"--force-with-lease=refs/heads/{branch}:",
+                    )
+                    if push.returncode != 0:
+                        return _result_from(
+                            plan,
+                            Status.BLOCKED,
+                            "branch_push_failed",
+                            "The automation branch push failed without creating a PR.",
+                            evidence={"push_stderr": push.stderr.strip()},
+                        )
+
+                repository = str(plan.evidence["source_repository"])
+                owner, repo_name = repository.split("/", 1)
+                marker = identity_marker(repository, source_number, plan.train_id)
+                body = render_pull_body(
+                    marker=marker,
+                    source_url=plan.source_pr or "",
+                    source_sha=source_sha,
+                    train_id=plan.train_id,
+                    source_body=str(plan.evidence["source_body"]),
+                )
+                url = self.github.create_pull(
+                    owner,
+                    repo_name,
+                    title=f"{plan.evidence['source_title']} (#{source_number})",
+                    body=body,
+                    head=branch,
+                    base=plan.target_branch,
+                )
+                return _result_from(
+                    plan,
+                    Status.DRAFT_CREATED,
+                    "draft_pull_created",
+                    "A draft cherry-pick pull request was created for operator review.",
+                    evidence={
+                        "automation_branch": branch,
+                        "automation_head": existing_branch or new_head,
+                        "reused_existing_branch": reused_branch,
+                    },
+                    pull_request_url=url,
+                )
+            finally:
+                _run(repo, "worktree", "remove", "--force", str(worktree))

--- a/scripts/render_express_train_workflow.py
+++ b/scripts/render_express_train_workflow.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Render the source-repository caller with one immutable rockrel revision."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+PLACEHOLDER = "ROCKREL_AUTOMATION_SHA"
+FULL_SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+
+
+class RenderError(ValueError):
+    """The template or requested automation revision is unsafe."""
+
+
+def render_workflow(template: str | Path, sha: str) -> str:
+    if FULL_SHA_RE.fullmatch(sha) is None:
+        raise RenderError("automation SHA must be a full lowercase 40-character SHA")
+    text = Path(template).read_text()
+    if PLACEHOLDER not in text:
+        raise RenderError(f"template does not contain {PLACEHOLDER} placeholder")
+    rendered = text.replace(PLACEHOLDER, sha)
+    if PLACEHOLDER in rendered:
+        raise RenderError("template placeholder was not fully replaced")
+    return rendered
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=Path(__file__).parents[1] / "templates/express_train_request.yml",
+    )
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    rendered = render_workflow(args.template, args.sha)
+    args.output.write_text(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/fixtures/express_train_0811.json
+++ b/scripts/tests/fixtures/express_train_0811.json
@@ -1,0 +1,45 @@
+{
+  "train_id": "10.1-20260811",
+  "target_branch": "release/bkc/therock-10.1-20260811",
+  "cases": [
+    {
+      "source_pr": "https://github.com/ROCm/TheRock/pull/7268",
+      "covering_pr": "https://github.com/ROCm/TheRock/pull/7355",
+      "expected_reason": "ordinary_patch_coverage"
+    },
+    {
+      "source_pr": "https://github.com/ROCm/TheRock/pull/7282",
+      "covering_pr": "https://github.com/ROCm/TheRock/pull/7357",
+      "expected_reason": "gitlink_cherry_pick_provenance",
+      "source_desired_pin": "a01cdbd92d1f931738a4897502747a68ae36eccf",
+      "covering_pin": "d177931e65e6057dca59f1c5b95e643d29876db3",
+      "common_origin": "1109d68feb1b746c675d8f88fb89085334f8f514",
+      "relationship": "diverged"
+    },
+    {
+      "source_pr": "https://github.com/ROCm/rocm-systems/pull/9923",
+      "covering_pr": "https://github.com/ROCm/rocm-systems/pull/10151",
+      "expected_reason": "ordinary_patch_coverage"
+    },
+    {
+      "source_pr": "https://github.com/ROCm/rocm-systems/pull/8793",
+      "covering_pr": "https://github.com/ROCm/rocm-systems/pull/10152",
+      "expected_reason": "ordinary_patch_coverage"
+    },
+    {
+      "source_pr": "https://github.com/ROCm/rocm-systems/pull/9716",
+      "covering_pr": "https://github.com/ROCm/rocm-systems/pull/10153",
+      "expected_reason": "ordinary_patch_coverage"
+    },
+    {
+      "source_pr": "https://github.com/ROCm/rocm-libraries/pull/10498",
+      "covering_pr": "https://github.com/ROCm/rocm-libraries/pull/10778",
+      "expected_reason": "ordinary_patch_coverage"
+    },
+    {
+      "source_pr": "https://github.com/ROCm/rocm-libraries/pull/10251",
+      "covering_pr": "https://github.com/ROCm/rocm-libraries/pull/10779",
+      "expected_reason": "ordinary_patch_coverage"
+    }
+  ]
+}

--- a/scripts/tests/test_express_train_0811_fixture.py
+++ b/scripts/tests/test_express_train_0811_fixture.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from scripts.express_train.clients import parse_pull_request_url
+
+
+FIXTURE = Path(__file__).parent / "fixtures/express_train_0811.json"
+
+
+def test_0811_fixture_contains_all_seven_unique_source_requests():
+    fixture = json.loads(FIXTURE.read_text())
+    cases = fixture["cases"]
+    assert fixture["train_id"] == "10.1-20260811"
+    assert fixture["target_branch"] == "release/bkc/therock-10.1-20260811"
+    assert len(cases) == 7
+    assert len({case["source_pr"] for case in cases}) == 7
+    assert len({case["covering_pr"] for case in cases}) == 7
+
+
+def test_0811_covering_prs_stay_in_the_source_repository():
+    fixture = json.loads(FIXTURE.read_text())
+    for case in fixture["cases"]:
+        source_owner, source_repo, _ = parse_pull_request_url(case["source_pr"])
+        target_owner, target_repo, _ = parse_pull_request_url(case["covering_pr"])
+        assert (source_owner, source_repo) == (target_owner, target_repo)
+
+
+def test_0811_compiler_case_records_divergent_patch_provenance():
+    fixture = json.loads(FIXTURE.read_text())
+    compiler = next(
+        case for case in fixture["cases"] if case["source_pr"].endswith("/7282")
+    )
+    assert compiler["expected_reason"] == "gitlink_cherry_pick_provenance"
+    assert compiler["relationship"] == "diverged"
+    assert compiler["source_desired_pin"] != compiler["covering_pin"]
+    assert len(compiler["common_origin"]) == 40

--- a/scripts/tests/test_express_train_cli.py
+++ b/scripts/tests/test_express_train_cli.py
@@ -1,0 +1,216 @@
+import io
+import json
+
+from scripts.express_train.__main__ import main
+from scripts.express_train.models import Result, Status
+
+
+class FakePlanner:
+    result = Result(
+        status=Status.CHERRY_PICK_REQUIRED,
+        reason_code="clean_trial_application",
+        message="clean",
+        source_pr="https://github.com/ROCm/TheRock/pull/7282",
+        train_id="10.1-20260811",
+        target_branch="release/test",
+        evidence={
+            "source_repository": "ROCm/TheRock",
+            "source_number": 7282,
+            "source_title": "Change ROCM-29371",
+            "source_body": "ROCM-29371",
+            "source_merge_commit": "a" * 40,
+            "target_head": "b" * 40,
+        },
+    )
+    calls = []
+
+    def __init__(self, config, github, jira):
+        self.config = config
+
+    def plan(self, source_pr, train_id, repo_dir):
+        self.calls.append((source_pr, train_id, str(repo_dir)))
+        return self.result
+
+
+class FakeWriter:
+    calls = []
+
+    def __init__(self, github):
+        pass
+
+    def create(self, repo_dir, train, plan):
+        self.calls.append((str(repo_dir), train.id, plan.status))
+        return Result(
+            status=Status.DRAFT_CREATED,
+            reason_code="draft_pull_created",
+            message="created",
+            source_pr=plan.source_pr,
+            train_id=plan.train_id,
+            target_branch=plan.target_branch,
+            pull_request_url="https://github.com/ROCm/TheRock/pull/9000",
+        )
+
+
+class FakeGitHub:
+    instances = []
+
+    def __init__(self, token):
+        self.token = token
+        self.labels = []
+        self.comments = []
+        self.instances.append(self)
+
+    def ensure_label(self, owner, repo, **kwargs):
+        self.labels.append((owner, repo, kwargs))
+
+    def upsert_comment(self, owner, repo, number, **kwargs):
+        self.comments.append((owner, repo, number, kwargs))
+
+
+class FakeJira:
+    def __init__(self, base_url, token):
+        self.base_url = base_url
+        self.token = token
+
+
+def config_file(tmp_path, mode="create-draft"):
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "trains": [
+                    {
+                        "id": "10.1-20260811",
+                        "jira_fix_version": "10.1.0a20260811",
+                        "state": "active",
+                        "mode": mode,
+                        "repositories": {
+                            "ROCm/TheRock": {
+                                "source_branch": "main",
+                                "target_branch": "release/test",
+                            }
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    return path
+
+
+def dependencies():
+    return {
+        "github_factory": FakeGitHub,
+        "jira_factory": FakeJira,
+        "planner_factory": FakePlanner,
+        "writer_factory": FakeWriter,
+    }
+
+
+def environment():
+    return {
+        "GITHUB_TOKEN": "github-token",
+        "JIRA_URL": "https://jira.example",
+        "JIRA_TOKEN": "jira-token",
+    }
+
+
+def test_plan_emits_json_and_never_constructs_writer(tmp_path):
+    FakePlanner.calls.clear()
+    FakeWriter.calls.clear()
+    output = io.StringIO()
+    code = main(
+        [
+            "--config",
+            str(config_file(tmp_path)),
+            "plan",
+            "--source-pr",
+            FakePlanner.result.source_pr,
+            "--train",
+            "10.1-20260811",
+            "--repo-dir",
+            str(tmp_path),
+        ],
+        environ=environment(),
+        stdout=output,
+        **dependencies(),
+    )
+    assert code == 0
+    assert json.loads(output.getvalue())["status"] == "cherry_pick_required"
+    assert FakeWriter.calls == []
+
+
+def test_create_draft_runs_writer_and_publishes_sticky_status(tmp_path):
+    FakeWriter.calls.clear()
+    FakeGitHub.instances.clear()
+    output = io.StringIO()
+    code = main(
+        [
+            "--config",
+            str(config_file(tmp_path)),
+            "create-draft",
+            "--source-pr",
+            FakePlanner.result.source_pr,
+            "--train",
+            "10.1-20260811",
+            "--repo-dir",
+            str(tmp_path),
+            "--publish-status",
+        ],
+        environ=environment(),
+        stdout=output,
+        **dependencies(),
+    )
+    assert code == 0
+    assert json.loads(output.getvalue())["status"] == "draft_created"
+    assert FakeWriter.calls
+    assert FakeGitHub.instances[-1].comments[0][3]["marker"].startswith(
+        "<!-- express-train-status:"
+    )
+
+
+def test_sync_labels_adds_only_configured_train_label(tmp_path):
+    FakeGitHub.instances.clear()
+    output = io.StringIO()
+    code = main(
+        [
+            "--config",
+            str(config_file(tmp_path)),
+            "sync-labels",
+            "--train",
+            "10.1-20260811",
+        ],
+        environ=environment(),
+        stdout=output,
+        **dependencies(),
+    )
+    assert code == 0
+    label = FakeGitHub.instances[-1].labels[0]
+    assert label[0:2] == ("ROCm", "TheRock")
+    assert label[2]["name"] == "express-train:10.1-20260811"
+
+
+def test_missing_credentials_fails_without_echoing_secret(tmp_path):
+    output = io.StringIO()
+    error = io.StringIO()
+    code = main(
+        [
+            "--config",
+            str(config_file(tmp_path)),
+            "plan",
+            "--source-pr",
+            FakePlanner.result.source_pr,
+            "--train",
+            "10.1-20260811",
+            "--repo-dir",
+            str(tmp_path),
+        ],
+        environ={},
+        stdout=output,
+        stderr=error,
+        **dependencies(),
+    )
+    assert code == 2
+    assert "GITHUB_TOKEN" in error.getvalue()
+    assert output.getvalue() == ""

--- a/scripts/tests/test_express_train_cli.py
+++ b/scripts/tests/test_express_train_cli.py
@@ -27,8 +27,8 @@ class FakePlanner:
     def __init__(self, config, github, jira):
         self.config = config
 
-    def plan(self, source_pr, train_id, repo_dir):
-        self.calls.append((source_pr, train_id, str(repo_dir)))
+    def plan(self, source_pr, train_id, repo_dir, *, event_action=None):
+        self.calls.append((source_pr, train_id, str(repo_dir), event_action))
         return self.result
 
 
@@ -134,6 +134,8 @@ def test_plan_emits_json_and_never_constructs_writer(tmp_path):
             "10.1-20260811",
             "--repo-dir",
             str(tmp_path),
+            "--event-action",
+            "unlabeled",
         ],
         environ=environment(),
         stdout=output,
@@ -142,6 +144,7 @@ def test_plan_emits_json_and_never_constructs_writer(tmp_path):
     assert code == 0
     assert json.loads(output.getvalue())["status"] == "cherry_pick_required"
     assert FakeWriter.calls == []
+    assert FakePlanner.calls[-1][3] == "unlabeled"
 
 
 def test_create_draft_runs_writer_and_publishes_sticky_status(tmp_path):

--- a/scripts/tests/test_express_train_cli.py
+++ b/scripts/tests/test_express_train_cli.py
@@ -66,6 +66,9 @@ class FakeGitHub:
     def upsert_comment(self, owner, repo, number, **kwargs):
         self.comments.append((owner, repo, number, kwargs))
 
+    def search_merged_labeled_pull_requests(self, owner, repo, label):
+        return [FakePlanner.result.source_pr]
+
 
 class FakeJira:
     def __init__(self, base_url, token):
@@ -214,3 +217,28 @@ def test_missing_credentials_fails_without_echoing_secret(tmp_path):
     assert code == 2
     assert "GITHUB_TOKEN" in error.getvalue()
     assert output.getvalue() == ""
+
+
+def test_reconcile_discovers_and_plans_labeled_merged_prs(tmp_path):
+    FakePlanner.calls.clear()
+    output = io.StringIO()
+    code = main(
+        [
+            "--config",
+            str(config_file(tmp_path)),
+            "reconcile",
+            "--train",
+            "10.1-20260811",
+            "--repo-dir",
+            f"ROCm/TheRock={tmp_path}",
+        ],
+        environ=environment(),
+        stdout=output,
+        **dependencies(),
+    )
+    assert code == 0
+    payload = json.loads(output.getvalue())
+    assert payload["status"] == "reconciled"
+    assert payload["mode"] == "plan"
+    assert payload["results"][0]["source_pr"].endswith("/pull/7282")
+    assert FakePlanner.calls[-1][2] == str(tmp_path)

--- a/scripts/tests/test_express_train_clients.py
+++ b/scripts/tests/test_express_train_clients.py
@@ -160,3 +160,18 @@ def test_github_search_returns_only_pull_request_urls():
 
     assert urls == ["https://github.com/ROCm/TheRock/pull/7282"]
     assert "is%3Amerged" in transport.requests[0][1]
+
+
+def test_github_commit_and_compare_use_encoded_commit_paths():
+    transport = FakeTransport(
+        [
+            {"sha": "a" * 40, "commit": {"message": "source"}},
+            {"status": "ahead", "commits": []},
+        ]
+    )
+    github = GitHubClient("token", transport=transport)
+    assert github.commit("ROCm", "llvm-project", "a" * 40)["sha"] == "a" * 40
+    assert github.compare("ROCm", "llvm-project", "a" * 40, "b" * 40)[
+        "status"
+    ] == "ahead"
+    assert "/compare/" in transport.requests[1][1]

--- a/scripts/tests/test_express_train_clients.py
+++ b/scripts/tests/test_express_train_clients.py
@@ -1,0 +1,138 @@
+import json
+
+import pytest
+
+from scripts.express_train.clients import (
+    ApiError,
+    GitHubClient,
+    JiraClient,
+    extract_jira_keys,
+    parse_pull_request_url,
+)
+
+
+class FakeTransport:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def request(self, method, url, *, headers=None, body=None):
+        self.requests.append((method, url, headers or {}, body))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def test_parse_pull_request_url_accepts_only_canonical_github_prs():
+    assert parse_pull_request_url("https://github.com/ROCm/TheRock/pull/7282") == (
+        "ROCm",
+        "TheRock",
+        7282,
+    )
+    with pytest.raises(ValueError):
+        parse_pull_request_url("https://example.com/ROCm/TheRock/pull/7282")
+    with pytest.raises(ValueError):
+        parse_pull_request_url("https://github.com/ROCm/TheRock/issues/7282")
+
+
+def test_extract_jira_keys_is_unique_and_case_normalized():
+    assert extract_jira_keys("Fix ROCM-29371 and rocm-29371; relates ROCM-9") == [
+        "ROCM-29371",
+        "ROCM-9",
+    ]
+
+
+def test_github_client_finds_last_exact_label_actor():
+    transport = FakeTransport(
+        [
+            [
+                {
+                    "event": "labeled",
+                    "label": {"name": "express-train:other"},
+                    "actor": {"login": "wrong"},
+                },
+                {
+                    "event": "labeled",
+                    "label": {"name": "express-train:10.1-20260811"},
+                    "actor": {"login": "first"},
+                },
+                {
+                    "event": "unlabeled",
+                    "label": {"name": "express-train:10.1-20260811"},
+                    "actor": {"login": "remover"},
+                },
+                {
+                    "event": "labeled",
+                    "label": {"name": "express-train:10.1-20260811"},
+                    "actor": {"login": "operator"},
+                },
+            ]
+        ]
+    )
+    github = GitHubClient("token", transport=transport)
+
+    assert github.label_actor("ROCm", "TheRock", 7282, "express-train:10.1-20260811") == "operator"
+    assert transport.requests[0][2]["Accept"].endswith("+json")
+
+
+def test_github_client_reads_current_permission_and_branch_protection():
+    transport = FakeTransport(
+        [
+            {"permission": "maintain"},
+            {"name": "release/bkc/test", "protected": True},
+        ]
+    )
+    github = GitHubClient("token", transport=transport)
+
+    assert github.permission("ROCm", "TheRock", "operator") == "maintain"
+    assert github.branch("ROCm", "TheRock", "release/bkc/test") == {
+        "exists": True,
+        "protected": True,
+        "sha": None,
+    }
+
+
+def test_missing_branch_is_a_fact_but_transport_errors_are_not():
+    missing = GitHubClient(
+        "token", transport=FakeTransport([ApiError(404, "not found")])
+    )
+    assert missing.branch("ROCm", "TheRock", "release/missing")["exists"] is False
+
+    broken = GitHubClient(
+        "token", transport=FakeTransport([ApiError(503, "unavailable")])
+    )
+    with pytest.raises(ApiError):
+        broken.branch("ROCm", "TheRock", "release/test")
+
+
+def test_jira_client_reads_fix_versions_with_bearer_auth():
+    transport = FakeTransport(
+        [{"fields": {"fixVersions": [{"name": "10.1.0a20260811"}]}}]
+    )
+    jira = JiraClient("https://jira.example", "secret", transport=transport)
+
+    assert jira.fix_versions("ROCM-29371") == {"10.1.0a20260811"}
+    method, url, headers, body = transport.requests[0]
+    assert method == "GET"
+    assert url.endswith("/rest/api/2/issue/ROCM-29371?fields=fixVersions")
+    assert headers["Authorization"] == "Bearer secret"
+    assert body is None
+
+
+def test_github_create_pull_forces_draft_true():
+    transport = FakeTransport([{"html_url": "https://github.com/ROCm/TheRock/pull/1"}])
+    github = GitHubClient("token", transport=transport)
+
+    url = github.create_pull(
+        "ROCm",
+        "TheRock",
+        title="change",
+        body="body",
+        head="shared/cherry-pick/train/1",
+        base="release/test",
+    )
+
+    assert url.endswith("/pull/1")
+    payload = json.loads(transport.requests[0][3].decode())
+    assert payload["draft"] is True

--- a/scripts/tests/test_express_train_clients.py
+++ b/scripts/tests/test_express_train_clients.py
@@ -136,3 +136,27 @@ def test_github_create_pull_forces_draft_true():
     assert url.endswith("/pull/1")
     payload = json.loads(transport.requests[0][3].decode())
     assert payload["draft"] is True
+
+
+def test_github_search_returns_only_pull_request_urls():
+    transport = FakeTransport(
+        [
+            {
+                "items": [
+                    {
+                        "html_url": "https://github.com/ROCm/TheRock/pull/7282",
+                        "pull_request": {"url": "api-url"},
+                    },
+                    {"html_url": "https://github.com/ROCm/TheRock/issues/1"},
+                ]
+            }
+        ]
+    )
+    github = GitHubClient("token", transport=transport)
+
+    urls = github.search_merged_labeled_pull_requests(
+        "ROCm", "TheRock", "express-train:10.1-20260811"
+    )
+
+    assert urls == ["https://github.com/ROCm/TheRock/pull/7282"]
+    assert "is%3Amerged" in transport.requests[0][1]

--- a/scripts/tests/test_express_train_config.py
+++ b/scripts/tests/test_express_train_config.py
@@ -1,0 +1,101 @@
+import json
+
+import pytest
+
+from scripts.express_train.config import ConfigError, load_config, parse_train_label
+
+
+def write_config(tmp_path, trains):
+    path = tmp_path / "trains.json"
+    path.write_text(json.dumps({"schema_version": 1, "trains": trains}))
+    return path
+
+
+def valid_train(**overrides):
+    train = {
+        "id": "10.1-20260811",
+        "jira_fix_version": "10.1.0a20260811",
+        "state": "active",
+        "mode": "validate",
+        "repositories": {
+            "ROCm/TheRock": {
+                "source_branch": "main",
+                "target_branch": "release/bkc/therock-10.1-20260811",
+            },
+            "ROCm/rocm-systems": {
+                "source_branch": "develop",
+                "target_branch": "release/bkc/therock-10.1-20260811",
+            },
+        },
+    }
+    train.update(overrides)
+    return train
+
+
+def test_loads_valid_configuration(tmp_path):
+    config = load_config(write_config(tmp_path, [valid_train()]))
+
+    train = config.train("10.1-20260811")
+    assert train.label == "express-train:10.1-20260811"
+    assert train.repositories["ROCm/TheRock"].source_branch == "main"
+    assert train.repositories["ROCm/rocm-systems"].target_branch.startswith(
+        "release/"
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("id", "bad train"),
+        ("jira_fix_version", ""),
+        ("state", "paused"),
+        ("mode", "write-everything"),
+    ],
+)
+def test_rejects_invalid_train_fields(tmp_path, field, value):
+    with pytest.raises(ConfigError):
+        load_config(write_config(tmp_path, [valid_train(**{field: value})]))
+
+
+def test_rejects_duplicate_train_ids(tmp_path):
+    with pytest.raises(ConfigError, match="duplicate train id"):
+        load_config(write_config(tmp_path, [valid_train(), valid_train()]))
+
+
+def test_rejects_unapproved_repository(tmp_path):
+    train = valid_train(
+        repositories={
+            "someone/fork": {
+                "source_branch": "main",
+                "target_branch": "release/example",
+            }
+        }
+    )
+    with pytest.raises(ConfigError, match="unsupported repository"):
+        load_config(write_config(tmp_path, [train]))
+
+
+def test_rejects_non_release_target(tmp_path):
+    train = valid_train(
+        repositories={
+            "ROCm/TheRock": {
+                "source_branch": "main",
+                "target_branch": "main",
+            }
+        }
+    )
+    with pytest.raises(ConfigError, match="must start with release/"):
+        load_config(write_config(tmp_path, [train]))
+
+
+@pytest.mark.parametrize(
+    "label,expected",
+    [
+        ("express-train:10.1-20260811", "10.1-20260811"),
+        ("bug", None),
+        ("express-train:", None),
+        ("express-train:bad train", None),
+    ],
+)
+def test_parse_train_label(label, expected):
+    assert parse_train_label(label) == expected

--- a/scripts/tests/test_express_train_coverage.py
+++ b/scripts/tests/test_express_train_coverage.py
@@ -1,0 +1,113 @@
+import subprocess
+
+from scripts.express_train.coverage import (
+    extract_cherry_pick_origin,
+    find_covering_pull,
+)
+
+
+def git(repo, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def commit(repo, message):
+    git(repo, "commit", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+class FakeGitHub:
+    def commit(self, owner, repo, sha):
+        assert (owner, repo) == ("ROCm", "llvm-project")
+        return {
+            "sha": sha,
+            "commit": {
+                "message": (
+                    "[AMDGPU] fix\n\n"
+                    "(cherry picked from commit "
+                    "1109d68feb1b746c675d8f88fb89085334f8f514)"
+                )
+            },
+        }
+
+    def compare(self, owner, repo, base, head):
+        assert (owner, repo) == ("ROCm", "llvm-project")
+        return {
+            "status": "diverged",
+            "commits": [self.commit(owner, repo, head)],
+        }
+
+
+def make_gitlink_repo(tmp_path):
+    repo = tmp_path / "therock"
+    repo.mkdir()
+    git(repo, "init", "-b", "main")
+    git(repo, "config", "user.name", "Express Train Test")
+    git(repo, "config", "user.email", "express-train@example.com")
+    (repo / ".gitmodules").write_text(
+        '[submodule "llvm-project"]\n'
+        "\tpath = compiler/amd-llvm\n"
+        "\turl = https://github.com/ROCm/llvm-project.git\n"
+    )
+    git(repo, "add", ".gitmodules")
+    old = "1" * 40
+    desired = "a01cdbd92d1f931738a4897502747a68ae36eccf"
+    candidate_pin = "d177931e65e6057dca59f1c5b95e643d29876db3"
+    git(repo, "update-index", "--add", "--cacheinfo", f"160000,{old},compiler/amd-llvm")
+    base = commit(repo, "base")
+    git(repo, "update-index", "--cacheinfo", f"160000,{desired},compiler/amd-llvm")
+    source = commit(repo, "source gitlink")
+    git(repo, "checkout", "--detach", base)
+    git(
+        repo,
+        "update-index",
+        "--cacheinfo",
+        f"160000,{candidate_pin},compiler/amd-llvm",
+    )
+    candidate = commit(repo, "candidate covering gitlink")
+    return repo, source, candidate
+
+
+def test_extracts_only_full_cherry_pick_origin_trailer():
+    assert extract_cherry_pick_origin(
+        "fix\n\n(cherry picked from commit "
+        "1109d68feb1b746c675d8f88fb89085334f8f514)"
+    ) == "1109d68feb1b746c675d8f88fb89085334f8f514"
+    assert extract_cherry_pick_origin("mentions 1109d68 but no trailer") is None
+
+
+def test_gitlink_divergence_is_covered_by_matching_original_commit(tmp_path):
+    repo, source, candidate = make_gitlink_repo(tmp_path)
+    pull = {
+        "number": 7357,
+        "state": "open",
+        "html_url": "https://github.com/ROCm/TheRock/pull/7357",
+        "head": {"sha": candidate, "ref": "users/example/covering"},
+    }
+
+    coverage = find_covering_pull(repo, FakeGitHub(), source, pull)
+
+    assert coverage is not None
+    assert coverage["reason"] == "gitlink_cherry_pick_provenance"
+    assert coverage["paths"] == ["compiler/amd-llvm"]
+    assert coverage["pull_request_url"].endswith("/7357")
+
+
+def test_0811_compiler_fixture_records_exact_non_ancestry_evidence():
+    fixture = {
+        "source_pr": 7282,
+        "covering_pr": 7357,
+        "source_desired_pin": "a01cdbd92d1f931738a4897502747a68ae36eccf",
+        "covering_pin": "d177931e65e6057dca59f1c5b95e643d29876db3",
+        "common_origin": "1109d68feb1b746c675d8f88fb89085334f8f514",
+        "relationship": "diverged",
+    }
+    assert fixture["relationship"] == "diverged"
+    assert fixture["source_desired_pin"] != fixture["covering_pin"]
+    assert len(fixture["common_origin"]) == 40

--- a/scripts/tests/test_express_train_git.py
+++ b/scripts/tests/test_express_train_git.py
@@ -1,0 +1,137 @@
+import subprocess
+
+import pytest
+
+from scripts.express_train.git import classify_gitlink, evaluate_cherry_pick
+from scripts.express_train.models import Status
+
+
+def git(repo, *args, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def commit_file(repo, path, content, message):
+    (repo / path).write_text(content)
+    git(repo, "add", path)
+    git(repo, "commit", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path):
+    path = tmp_path / "repo"
+    path.mkdir()
+    git(path, "init", "-b", "main")
+    git(path, "config", "user.name", "Express Train Test")
+    git(path, "config", "user.email", "express-train@example.com")
+    commit_file(path, "value.txt", "base\n", "base")
+    return path
+
+
+def test_clean_change_is_required_without_mutating_checkout(repo):
+    base = git(repo, "rev-parse", "HEAD")
+    source = commit_file(repo, "source.txt", "change\n", "source")
+    git(repo, "branch", "release/test", base)
+    original_head = git(repo, "rev-parse", "HEAD")
+
+    result = evaluate_cherry_pick(repo, source, "release/test")
+
+    assert result.status is Status.CHERRY_PICK_REQUIRED
+    assert result.evidence["target_head"] == base
+    assert git(repo, "rev-parse", "HEAD") == original_head
+    assert git(repo, "status", "--porcelain") == ""
+
+
+def test_reachable_source_is_already_contained(repo):
+    source = commit_file(repo, "source.txt", "change\n", "source")
+    target = commit_file(repo, "later.txt", "later\n", "target descendant")
+
+    result = evaluate_cherry_pick(repo, source, target)
+
+    assert result.status is Status.ALREADY_CONTAINED
+    assert result.reason_code == "source_ancestor_of_target"
+
+
+def test_patch_equivalent_target_is_already_contained(repo):
+    base = git(repo, "rev-parse", "HEAD")
+    source = commit_file(repo, "equivalent.txt", "same\n", "source")
+    git(repo, "checkout", "--detach", base)
+    equivalent = commit_file(repo, "equivalent.txt", "same\n", "independent target")
+
+    result = evaluate_cherry_pick(repo, source, equivalent)
+
+    assert result.status is Status.ALREADY_CONTAINED
+    assert result.reason_code == "empty_trial_application"
+
+
+def test_conflict_requires_manual_resolution(repo):
+    base = git(repo, "rev-parse", "HEAD")
+    source = commit_file(repo, "value.txt", "source\n", "source")
+    git(repo, "checkout", "--detach", base)
+    target = commit_file(repo, "value.txt", "target\n", "target")
+
+    result = evaluate_cherry_pick(repo, source, target)
+
+    assert result.status is Status.MANUAL_RESOLUTION_REQUIRED
+    assert result.reason_code == "cherry_pick_conflict"
+
+
+def test_missing_source_blocks(repo):
+    result = evaluate_cherry_pick(repo, "f" * 40, "main")
+    assert result.status is Status.BLOCKED
+    assert result.reason_code == "source_commit_missing"
+
+
+def test_two_parent_merge_uses_first_parent(repo):
+    base = git(repo, "rev-parse", "HEAD")
+    git(repo, "checkout", "-b", "topic")
+    commit_file(repo, "topic.txt", "topic\n", "topic")
+    git(repo, "checkout", "main")
+    commit_file(repo, "main.txt", "main\n", "main")
+    git(repo, "merge", "--no-ff", "topic", "-m", "merge topic")
+    merge_commit = git(repo, "rev-parse", "HEAD")
+    git(repo, "branch", "release/test", base)
+
+    result = evaluate_cherry_pick(repo, merge_commit, "release/test")
+
+    assert result.status is Status.CHERRY_PICK_REQUIRED
+    assert result.evidence["mainline"] == 1
+
+
+def test_gitlink_equal_and_target_descendant_are_contained(repo):
+    desired = commit_file(repo, "one.txt", "one\n", "desired")
+    target = commit_file(repo, "two.txt", "two\n", "target descendant")
+
+    assert classify_gitlink(repo, desired, desired).status is Status.ALREADY_CONTAINED
+    descendant = classify_gitlink(repo, desired, target)
+    assert descendant.status is Status.ALREADY_CONTAINED
+    assert descendant.reason_code == "target_pin_contains_desired"
+
+
+def test_gitlink_target_ancestor_requires_update(repo):
+    target = git(repo, "rev-parse", "HEAD")
+    desired = commit_file(repo, "new.txt", "new\n", "desired descendant")
+
+    result = classify_gitlink(repo, desired, target)
+
+    assert result.status is Status.CHERRY_PICK_REQUIRED
+    assert result.reason_code == "desired_pin_ahead_of_target"
+
+
+def test_gitlink_divergence_requires_manual_resolution(repo):
+    base = git(repo, "rev-parse", "HEAD")
+    desired = commit_file(repo, "desired.txt", "desired\n", "desired")
+    git(repo, "checkout", "--detach", base)
+    target = commit_file(repo, "target.txt", "target\n", "target")
+
+    result = classify_gitlink(repo, desired, target)
+
+    assert result.status is Status.MANUAL_RESOLUTION_REQUIRED
+    assert result.reason_code == "gitlink_histories_diverged"

--- a/scripts/tests/test_express_train_orchestrator.py
+++ b/scripts/tests/test_express_train_orchestrator.py
@@ -101,6 +101,37 @@ def test_deterministic_branch_prevents_duplicate_without_marker(tmp_path):
     assert result.status is Status.COVERED_BY_EXISTING_PR
 
 
+def test_proven_covering_pull_prevents_duplicate_without_marker(tmp_path):
+    candidate = {
+        "number": 7357,
+        "state": "open",
+        "html_url": "https://github.com/ROCm/TheRock/pull/7357",
+        "body": "independent compiler pin update",
+        "head": {"ref": "users/compiler-update", "sha": "c" * 40},
+    }
+    coverage = Mock(
+        return_value={
+            "reason": "gitlink_cherry_pick_provenance",
+            "paths": ["compiler/amd-llvm"],
+            "pull_request_url": candidate["html_url"],
+        }
+    )
+    evaluator = Mock()
+    result = Planner(
+        config(),
+        github([candidate]),
+        jira(),
+        evaluator=evaluator,
+        coverage_evaluator=coverage,
+    ).plan(SOURCE_URL, "10.1-20260811", tmp_path)
+
+    assert result.status is Status.COVERED_BY_EXISTING_PR
+    assert result.reason_code == "gitlink_cherry_pick_provenance"
+    assert result.pull_request_url.endswith("/7357")
+    coverage.assert_called_once()
+    evaluator.assert_not_called()
+
+
 def test_clean_plan_includes_source_and_target_evidence(tmp_path):
     evaluator = Mock(
         return_value=Result(

--- a/scripts/tests/test_express_train_orchestrator.py
+++ b/scripts/tests/test_express_train_orchestrator.py
@@ -1,0 +1,161 @@
+from unittest.mock import Mock
+
+from scripts.express_train.config import ExpressTrainConfig, RepositoryConfig, TrainConfig
+from scripts.express_train.models import Result, Status
+from scripts.express_train.orchestrator import (
+    Planner,
+    automation_branch,
+    identity_marker,
+    render_pull_body,
+)
+
+
+SOURCE_URL = "https://github.com/ROCm/TheRock/pull/7282"
+SOURCE_SHA = "a" * 40
+TARGET_SHA = "b" * 40
+
+
+def config(mode="validate"):
+    train = TrainConfig(
+        id="10.1-20260811",
+        jira_fix_version="10.1.0a20260811",
+        state="active",
+        mode=mode,
+        repositories={
+            "ROCm/TheRock": RepositoryConfig(
+                source_branch="main",
+                target_branch="release/bkc/therock-10.1-20260811",
+            )
+        },
+    )
+    return ExpressTrainConfig(trains={train.id: train})
+
+
+def github(pulls=None, merged=True):
+    client = Mock()
+    client.pull.return_value = {
+        "number": 7282,
+        "html_url": SOURCE_URL,
+        "title": "chore(compiler): SMP for Compiler ww23.20 ROCM-29371",
+        "body": "Take ROCM-29371",
+        "state": "closed" if merged else "open",
+        "merged": merged,
+        "merge_commit_sha": SOURCE_SHA if merged else None,
+        "base": {"ref": "main"},
+        "labels": [{"name": "express-train:10.1-20260811"}],
+    }
+    client.label_actor.return_value = "operator"
+    client.permission.return_value = "write"
+    client.branch.return_value = {
+        "exists": True,
+        "protected": True,
+        "sha": TARGET_SHA,
+    }
+    client.pulls.return_value = pulls or []
+    return client
+
+
+def jira():
+    client = Mock()
+    client.fix_versions.return_value = {"10.1.0a20260811"}
+    return client
+
+
+def test_open_pr_waits_without_calling_git(tmp_path):
+    evaluator = Mock()
+    result = Planner(config(), github(merged=False), jira(), evaluator=evaluator).plan(
+        SOURCE_URL, "10.1-20260811", tmp_path
+    )
+    assert result.status is Status.WAITING_FOR_MERGE
+    evaluator.assert_not_called()
+
+
+def test_existing_marker_prevents_duplicate(tmp_path):
+    marker = identity_marker("ROCm/TheRock", 7282, "10.1-20260811")
+    existing = {
+        "html_url": "https://github.com/ROCm/TheRock/pull/7357",
+        "body": f"Existing coverage\n{marker}",
+        "head": {"ref": "some-branch", "sha": "c" * 40},
+    }
+    evaluator = Mock()
+    result = Planner(
+        config(), github([existing]), jira(), evaluator=evaluator
+    ).plan(SOURCE_URL, "10.1-20260811", tmp_path)
+    assert result.status is Status.COVERED_BY_EXISTING_PR
+    assert result.pull_request_url.endswith("/7357")
+    evaluator.assert_not_called()
+
+
+def test_deterministic_branch_prevents_duplicate_without_marker(tmp_path):
+    existing = {
+        "html_url": "https://github.com/ROCm/TheRock/pull/9000",
+        "body": "",
+        "head": {
+            "ref": "shared/cherry-pick/10.1-20260811/7282",
+            "sha": "c" * 40,
+        },
+    }
+    result = Planner(config(), github([existing]), jira()).plan(
+        SOURCE_URL, "10.1-20260811", tmp_path
+    )
+    assert result.status is Status.COVERED_BY_EXISTING_PR
+
+
+def test_clean_plan_includes_source_and_target_evidence(tmp_path):
+    evaluator = Mock(
+        return_value=Result(
+            status=Status.CHERRY_PICK_REQUIRED,
+            reason_code="clean_trial_application",
+            message="clean",
+            evidence={"source_commit": SOURCE_SHA, "target_head": TARGET_SHA},
+        )
+    )
+    result = Planner(config(), github(), jira(), evaluator=evaluator).plan(
+        SOURCE_URL, "10.1-20260811", tmp_path
+    )
+    assert result.status is Status.CHERRY_PICK_REQUIRED
+    assert result.source_pr == SOURCE_URL
+    assert result.target_branch == "release/bkc/therock-10.1-20260811"
+    assert result.evidence["source_title"].startswith("chore(compiler)")
+    evaluator.assert_called_once_with(tmp_path, SOURCE_SHA, TARGET_SHA)
+
+
+def test_missing_train_label_is_invalid(tmp_path):
+    client = github()
+    client.pull.return_value["labels"] = []
+    result = Planner(config(), client, jira()).plan(
+        SOURCE_URL, "10.1-20260811", tmp_path
+    )
+    assert result.status is Status.INVALID
+    assert result.reason_code == "train_label_missing"
+
+
+def test_jira_transport_failure_blocks(tmp_path):
+    jira_client = jira()
+    jira_client.fix_versions.side_effect = RuntimeError("timeout")
+    result = Planner(config(), github(), jira_client).plan(
+        SOURCE_URL, "10.1-20260811", tmp_path
+    )
+    assert result.status is Status.BLOCKED
+    assert result.reason_code == "evidence_unavailable"
+
+
+def test_identity_and_pull_rendering_are_stable():
+    assert automation_branch("10.1-20260811", 7282) == (
+        "shared/cherry-pick/10.1-20260811/7282"
+    )
+    marker = identity_marker("ROCm/TheRock", 7282, "10.1-20260811")
+    assert marker == "<!-- express-train:ROCm/TheRock#7282:10.1-20260811 -->"
+
+    body = render_pull_body(
+        marker=marker,
+        source_url=SOURCE_URL,
+        source_sha=SOURCE_SHA,
+        train_id="10.1-20260811",
+        source_body="Take ROCM-29371",
+    )
+    assert marker in body
+    assert SOURCE_URL in body
+    assert SOURCE_SHA in body
+    assert "ROCM-29371" in body
+    assert "remains a draft" in body

--- a/scripts/tests/test_express_train_orchestrator.py
+++ b/scripts/tests/test_express_train_orchestrator.py
@@ -130,6 +130,17 @@ def test_missing_train_label_is_invalid(tmp_path):
     assert result.reason_code == "train_label_missing"
 
 
+def test_unlabeled_event_is_cancelled_even_after_label_is_removed(tmp_path):
+    client = github()
+    client.pull.return_value["labels"] = []
+    result = Planner(config(), client, jira()).plan(
+        SOURCE_URL, "10.1-20260811", tmp_path, event_action="unlabeled"
+    )
+    assert result.status is Status.CANCELLED
+    assert result.reason_code == "train_label_removed"
+    client.label_actor.assert_not_called()
+
+
 def test_jira_transport_failure_blocks(tmp_path):
     jira_client = jira()
     jira_client.fix_versions.side_effect = RuntimeError("timeout")

--- a/scripts/tests/test_express_train_policy.py
+++ b/scripts/tests/test_express_train_policy.py
@@ -1,0 +1,107 @@
+from scripts.express_train.config import RepositoryConfig, TrainConfig
+from scripts.express_train.models import Status
+from scripts.express_train.policy import QualificationFacts, qualify_request
+
+
+def train(**overrides):
+    value = TrainConfig(
+        id="10.1-20260811",
+        jira_fix_version="10.1.0a20260811",
+        state="active",
+        mode="validate",
+        repositories={
+            "ROCm/TheRock": RepositoryConfig(
+                source_branch="main",
+                target_branch="release/bkc/therock-10.1-20260811",
+            )
+        },
+    )
+    return TrainConfig(**({**value.__dict__, **overrides}))
+
+
+def facts(**overrides):
+    value = {
+        "source_pr": "https://github.com/ROCm/TheRock/pull/123",
+        "repository": "ROCm/TheRock",
+        "base_branch": "main",
+        "merged": True,
+        "closed": True,
+        "label_actor_permission": "write",
+        "jira_fix_versions": frozenset({"10.1.0a20260811"}),
+        "target_exists": True,
+        "target_protected": True,
+        "evidence_errors": (),
+    }
+    value.update(overrides)
+    return QualificationFacts(**value)
+
+
+def test_qualified_merged_request_advances_to_planning():
+    result = qualify_request(train(), facts())
+    assert result.status is Status.CHERRY_PICK_REQUIRED
+    assert result.reason_code == "qualified_for_planning"
+
+
+def test_open_request_waits_for_merge():
+    result = qualify_request(train(), facts(merged=False, closed=False))
+    assert result.status is Status.WAITING_FOR_MERGE
+
+
+def test_closed_unmerged_request_is_cancelled():
+    result = qualify_request(train(), facts(merged=False, closed=True))
+    assert result.status is Status.CANCELLED
+
+
+def test_transient_evidence_failure_blocks_and_is_not_invalid():
+    result = qualify_request(train(), facts(evidence_errors=("jira_timeout",)))
+    assert result.status is Status.BLOCKED
+    assert result.reason_code == "evidence_unavailable"
+
+
+def test_inactive_train_is_invalid():
+    result = qualify_request(train(state="inactive"), facts())
+    assert result.status is Status.INVALID
+    assert result.reason_code == "inactive_train"
+
+
+def test_unconfigured_repository_is_invalid():
+    result = qualify_request(train(), facts(repository="ROCm/other"))
+    assert result.status is Status.INVALID
+    assert result.reason_code == "repository_not_configured"
+
+
+def test_wrong_source_base_is_invalid():
+    result = qualify_request(train(), facts(base_branch="release/old"))
+    assert result.status is Status.INVALID
+    assert result.reason_code == "source_branch_mismatch"
+
+
+def test_unauthorized_labeler_is_invalid():
+    result = qualify_request(train(), facts(label_actor_permission="read"))
+    assert result.status is Status.INVALID
+    assert result.reason_code == "label_actor_not_authorized"
+
+
+def test_missing_fix_version_is_invalid():
+    result = qualify_request(train(), facts(jira_fix_versions=frozenset({"10.2"})))
+    assert result.status is Status.INVALID
+    assert result.reason_code == "jira_fix_version_mismatch"
+
+
+def test_missing_target_is_invalid():
+    result = qualify_request(train(), facts(target_exists=False))
+    assert result.status is Status.INVALID
+    assert result.reason_code == "target_branch_missing"
+
+
+def test_unprotected_target_is_invalid():
+    result = qualify_request(train(), facts(target_protected=False))
+    assert result.status is Status.INVALID
+    assert result.reason_code == "target_branch_not_protected"
+
+
+def test_maintain_and_admin_permissions_are_authorized():
+    for permission in ("maintain", "admin"):
+        assert qualify_request(
+            train(), facts(label_actor_permission=permission)
+        ).status is Status.CHERRY_PICK_REQUIRED

--- a/scripts/tests/test_express_train_workflows.py
+++ b/scripts/tests/test_express_train_workflows.py
@@ -61,5 +61,6 @@ def test_reconciliation_defaults_to_plan_only():
     text = workflow_text(RECONCILE)
     assert "mode: plan" in text
     assert "schedule:" in text
-    assert "python3 -m scripts.express_train reconcile" in text
+    assert "python3 -m scripts.express_train" in text
+    assert '            reconcile \\' in text
     assert "uses: ROCm/rockrel/.github/workflows/" not in text

--- a/scripts/tests/test_express_train_workflows.py
+++ b/scripts/tests/test_express_train_workflows.py
@@ -61,3 +61,5 @@ def test_reconciliation_defaults_to_plan_only():
     text = workflow_text(RECONCILE)
     assert "mode: plan" in text
     assert "schedule:" in text
+    assert "python3 -m scripts.express_train reconcile" in text
+    assert "uses: ROCm/rockrel/.github/workflows/" not in text

--- a/scripts/tests/test_express_train_workflows.py
+++ b/scripts/tests/test_express_train_workflows.py
@@ -1,0 +1,63 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+CENTRAL = ROOT / ".github/workflows/express_train_cherry_pick.yml"
+RECONCILE = ROOT / ".github/workflows/express_train_reconcile.yml"
+SYNC = ROOT / ".github/workflows/express_train_sync_labels.yml"
+TEMPLATE = ROOT / "templates/express_train_request.yml"
+FULL_SHA_USE = re.compile(r"uses:\s+[^\s]+@[0-9a-f]{40}(?:\s|$)", re.MULTILINE)
+
+
+def workflow_text(path):
+    assert path.exists(), f"missing workflow: {path}"
+    return path.read_text()
+
+
+def test_central_workflow_supports_reuse_and_manual_replay():
+    text = workflow_text(CENTRAL)
+    assert "workflow_call:" in text
+    assert "workflow_dispatch:" in text
+    assert "source_pr:" in text
+    assert "train_id:" in text
+    assert "automation_ref:" in text
+
+
+def test_workflows_pin_every_external_action_to_full_sha():
+    for path in (CENTRAL, RECONCILE, SYNC):
+        text = workflow_text(path)
+        uses_lines = [line for line in text.splitlines() if "uses:" in line]
+        assert uses_lines
+        assert all(FULL_SHA_USE.search(line) for line in uses_lines), uses_lines
+
+
+def test_privileged_workflow_never_references_pull_request_head_code():
+    for path in (CENTRAL, TEMPLATE):
+        text = workflow_text(path)
+        assert "pull_request.head" not in text
+        assert "github.head_ref" not in text
+        assert "ref: ${{ github.event.pull_request" not in text
+
+
+def test_app_write_token_is_limited_to_create_draft_job():
+    text = workflow_text(CENTRAL)
+    assert "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349" in text
+    assert "if: inputs.mode == 'create-draft'" in text
+    assert "permissions:\n  contents: read" in text
+    assert "secrets: inherit" not in text
+
+
+def test_source_template_uses_only_named_secrets_and_safe_event_metadata():
+    text = workflow_text(TEMPLATE)
+    assert "pull_request_target:" in text
+    assert "types: [labeled, unlabeled, closed]" in text
+    assert "secrets: inherit" not in text
+    assert "app_id: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}" in text
+    assert "jira_token: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}" in text
+
+
+def test_reconciliation_defaults_to_plan_only():
+    text = workflow_text(RECONCILE)
+    assert "mode: plan" in text
+    assert "schedule:" in text

--- a/scripts/tests/test_express_train_workflows.py
+++ b/scripts/tests/test_express_train_workflows.py
@@ -22,6 +22,8 @@ def test_central_workflow_supports_reuse_and_manual_replay():
     assert "source_pr:" in text
     assert "train_id:" in text
     assert "automation_ref:" in text
+    assert "event_action:" in text
+    assert "--event-action" in text
 
 
 def test_workflows_pin_every_external_action_to_full_sha():
@@ -55,6 +57,7 @@ def test_source_template_uses_only_named_secrets_and_safe_event_metadata():
     assert "secrets: inherit" not in text
     assert "app_id: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}" in text
     assert "jira_token: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}" in text
+    assert "event_action: ${{ github.event.action }}" in text
 
 
 def test_reconciliation_defaults_to_plan_only():

--- a/scripts/tests/test_express_train_workflows.py
+++ b/scripts/tests/test_express_train_workflows.py
@@ -45,7 +45,10 @@ def test_privileged_workflow_never_references_pull_request_head_code():
 def test_app_write_token_is_limited_to_create_draft_job():
     text = workflow_text(CENTRAL)
     assert "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349" in text
-    assert "if: inputs.mode == 'create-draft'" in text
+    assert "needs.plan.outputs.train_mode == 'create-draft'" in text
+    assert "needs.plan.outputs.status == 'cherry_pick_required'" in text
+    assert "train_mode: ${{ steps.result.outputs.train_mode }}" in text
+    assert "status: ${{ steps.result.outputs.status }}" in text
     assert "permissions:\n  contents: read" in text
     assert "secrets: inherit" not in text
 

--- a/scripts/tests/test_express_train_workflows.py
+++ b/scripts/tests/test_express_train_workflows.py
@@ -55,8 +55,8 @@ def test_source_template_uses_only_named_secrets_and_safe_event_metadata():
     assert "pull_request_target:" in text
     assert "types: [labeled, unlabeled, closed]" in text
     assert "secrets: inherit" not in text
-    assert "app_id: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}" in text
-    assert "jira_token: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}" in text
+    assert "ROCM_CHERRYPICK_APP_ID: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}" in text
+    assert "ROCM_CHERRYPICK_JIRA_TOKEN: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}" in text
     assert "event_action: ${{ github.event.action }}" in text
 
 

--- a/scripts/tests/test_express_train_writer.py
+++ b/scripts/tests/test_express_train_writer.py
@@ -1,0 +1,139 @@
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
+from scripts.express_train.config import RepositoryConfig, TrainConfig
+from scripts.express_train.models import Result, Status
+from scripts.express_train.writer import DraftWriter
+
+
+def git(repo, *args, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def commit_file(repo, path, content, message):
+    (repo / path).write_text(content)
+    git(repo, "add", path)
+    git(repo, "commit", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repositories(tmp_path):
+    remote = tmp_path / "remote.git"
+    git(tmp_path, "init", "--bare", str(remote))
+    repo = tmp_path / "work"
+    git(tmp_path, "clone", str(remote), str(repo))
+    git(repo, "config", "user.name", "Express Train Test")
+    git(repo, "config", "user.email", "express-train@example.com")
+    git(repo, "checkout", "-b", "main")
+    base = commit_file(repo, "value.txt", "base\n", "base")
+    git(repo, "push", "origin", "main")
+    git(repo, "branch", "release/test", base)
+    git(repo, "push", "origin", "release/test")
+    source = commit_file(repo, "source.txt", "source\n", "source")
+    git(repo, "push", "origin", "main")
+    return repo, remote, base, source
+
+
+def train(mode="create-draft"):
+    return TrainConfig(
+        id="10.1-20260811",
+        jira_fix_version="10.1.0a20260811",
+        state="active",
+        mode=mode,
+        repositories={
+            "ROCm/TheRock": RepositoryConfig(
+                source_branch="main", target_branch="release/test"
+            )
+        },
+    )
+
+
+def plan(base, source):
+    return Result(
+        status=Status.CHERRY_PICK_REQUIRED,
+        reason_code="clean_trial_application",
+        message="clean",
+        source_pr="https://github.com/ROCm/TheRock/pull/7282",
+        train_id="10.1-20260811",
+        target_branch="release/test",
+        evidence={
+            "source_repository": "ROCm/TheRock",
+            "source_number": 7282,
+            "source_title": "Compiler update ROCM-29371",
+            "source_body": "Take ROCM-29371",
+            "source_merge_commit": source,
+            "target_head": base,
+        },
+    )
+
+
+def test_creates_deterministic_branch_and_draft_pull(repositories):
+    repo, remote, base, source = repositories
+    github = Mock()
+    github.create_pull.return_value = "https://github.com/ROCm/TheRock/pull/9000"
+
+    result = DraftWriter(github).create(repo, train(), plan(base, source))
+
+    assert result.status is Status.DRAFT_CREATED
+    branch = "shared/cherry-pick/10.1-20260811/7282"
+    assert git(remote, "show-ref", "--verify", f"refs/heads/{branch}")
+    kwargs = github.create_pull.call_args.kwargs
+    assert kwargs["head"] == branch
+    assert kwargs["base"] == "release/test"
+    assert "ROCM-29371" in kwargs["body"]
+    assert "express-train:ROCm/TheRock#7282:10.1-20260811" in kwargs["body"]
+
+
+def test_refuses_write_outside_create_draft_mode(repositories):
+    repo, remote, base, source = repositories
+    github = Mock()
+
+    result = DraftWriter(github).create(repo, train("shadow"), plan(base, source))
+
+    assert result.status is Status.BLOCKED
+    assert result.reason_code == "write_mode_disabled"
+    github.create_pull.assert_not_called()
+
+
+def test_target_head_movement_blocks_before_push(repositories):
+    repo, remote, base, source = repositories
+    git(repo, "checkout", "release/test")
+    moved = commit_file(repo, "moved.txt", "moved\n", "move target")
+    git(repo, "push", "origin", "release/test")
+    github = Mock()
+
+    result = DraftWriter(github).create(repo, train(), plan(base, source))
+
+    assert result.status is Status.BLOCKED
+    assert result.reason_code == "target_head_moved"
+    assert result.evidence["actual_target_head"] == moved
+    github.create_pull.assert_not_called()
+
+
+def test_conflict_pushes_nothing(repositories):
+    repo, remote, base, _ = repositories
+    git(repo, "checkout", "main")
+    source = commit_file(repo, "value.txt", "source\n", "source conflict")
+    git(repo, "push", "origin", "main")
+    git(repo, "checkout", "release/test")
+    target = commit_file(repo, "value.txt", "target\n", "target conflict")
+    git(repo, "push", "origin", "release/test")
+    github = Mock()
+
+    result = DraftWriter(github).create(repo, train(), plan(target, source))
+
+    assert result.status is Status.MANUAL_RESOLUTION_REQUIRED
+    assert result.reason_code == "cherry_pick_conflict"
+    branch = "refs/heads/shared/cherry-pick/10.1-20260811/7282"
+    assert git(remote, "show-ref", "--verify", branch, check=False) == ""
+    github.create_pull.assert_not_called()

--- a/scripts/tests/test_render_express_train_workflow.py
+++ b/scripts/tests/test_render_express_train_workflow.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.render_express_train_workflow import RenderError, render_workflow
+
+
+def test_renders_every_placeholder_to_immutable_sha(tmp_path):
+    template = tmp_path / "template.yml"
+    template.write_text(
+        "uses: ROCm/rockrel/.github/workflows/x.yml@ROCKREL_AUTOMATION_SHA\n"
+        "with:\n  automation_ref: ROCKREL_AUTOMATION_SHA\n"
+    )
+    sha = "a" * 40
+
+    rendered = render_workflow(template, sha)
+
+    assert "ROCKREL_AUTOMATION_SHA" not in rendered
+    assert rendered.count(sha) == 2
+
+
+@pytest.mark.parametrize("sha", ["main", "abc123", "A" * 40, "g" * 40])
+def test_rejects_mutable_or_invalid_ref(tmp_path, sha):
+    template = tmp_path / "template.yml"
+    template.write_text("ROCKREL_AUTOMATION_SHA\n")
+    with pytest.raises(RenderError, match="full lowercase"):
+        render_workflow(template, sha)
+
+
+def test_rejects_template_without_placeholder(tmp_path):
+    template = tmp_path / "template.yml"
+    template.write_text("name: no placeholder\n")
+    with pytest.raises(RenderError, match="placeholder"):
+        render_workflow(template, "a" * 40)

--- a/templates/express_train_request.yml
+++ b/templates/express_train_request.yml
@@ -49,8 +49,9 @@ jobs:
       train_id: ${{ matrix.train }}
       automation_ref: ROCKREL_AUTOMATION_SHA
       mode: create-draft
+      event_action: ${{ github.event.action }}
     secrets:
-      app_id: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}
-      app_private_key: ${{ secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
-      jira_url: ${{ secrets.ROCM_CHERRYPICK_JIRA_URL }}
-      jira_token: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}
+      ROCM_CHERRYPICK_APP_ID: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}
+      ROCM_CHERRYPICK_APP_PRIVATE_KEY: ${{ secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
+      ROCM_CHERRYPICK_JIRA_URL: ${{ secrets.ROCM_CHERRYPICK_JIRA_URL }}
+      ROCM_CHERRYPICK_JIRA_TOKEN: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}

--- a/templates/express_train_request.yml
+++ b/templates/express_train_request.yml
@@ -1,0 +1,56 @@
+# Copy this file to .github/workflows/express_train_request.yml and replace
+# ROCKREL_AUTOMATION_SHA with the reviewed immutable rockrel commit SHA.
+name: Express Train cherry-pick request
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-24.04
+    outputs:
+      trains: ${{ steps.labels.outputs.trains }}
+    steps:
+      - name: Select Express Train labels from event metadata
+        id: labels
+        env:
+          ACTION: ${{ github.event.action }}
+          EVENT_LABEL: ${{ github.event.label.name }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          labels = json.loads(os.environ["PR_LABELS"])
+          event_label = os.environ.get("EVENT_LABEL", "")
+          if event_label.startswith("express-train:"):
+              labels.append(event_label)
+          trains = sorted({label.split(":", 1)[1] for label in labels if label.startswith("express-train:")})
+          print(f"trains={json.dumps(trains)}")
+          PY
+
+  process:
+    needs: discover
+    if: needs.discover.outputs.trains != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        train: ${{ fromJSON(needs.discover.outputs.trains) }}
+    uses: ROCm/rockrel/.github/workflows/express_train_cherry_pick.yml@ROCKREL_AUTOMATION_SHA
+    with:
+      source_pr: ${{ github.event.pull_request.html_url }}
+      train_id: ${{ matrix.train }}
+      automation_ref: ROCKREL_AUTOMATION_SHA
+      mode: create-draft
+    secrets:
+      app_id: ${{ secrets.ROCM_CHERRYPICK_APP_ID }}
+      app_private_key: ${{ secrets.ROCM_CHERRYPICK_APP_PRIVATE_KEY }}
+      jira_url: ${{ secrets.ROCM_CHERRYPICK_JIRA_URL }}
+      jira_token: ${{ secrets.ROCM_CHERRYPICK_JIRA_TOKEN }}

--- a/templates/express_train_request.yml
+++ b/templates/express_train_request.yml
@@ -1,5 +1,5 @@
-# Copy this file to .github/workflows/express_train_request.yml and replace
-# ROCKREL_AUTOMATION_SHA with the reviewed immutable rockrel commit SHA.
+# Generated callers must pin both rockrel references below to the same reviewed
+# immutable commit SHA. Use scripts/render_express_train_workflow.py.
 name: Express Train cherry-pick request
 
 on:


### PR DESCRIPTION
## Summary

- adds a GitHub-native Express Train label workflow modeled on the LinkedIn approach
- centralizes qualification, Git planning, duplicate coverage, and draft-only creation in rockrel
- adds reusable, reconciliation, and label-sync workflows plus source-repository templates
- documents product requirements, technical design, operations, and rollout

## Safety

- generated pull requests are always drafts
- no ready, review, merge, or auto-merge API exists
- validation and shadow modes cannot mint the GitHub App write token
- privileged workflows never execute source PR head code
- conflicts and unavailable evidence fail closed

## Test plan

- 132 pytest tests pass
- all repository pre-commit hooks pass, including actionlint
- all seven 0811 requests are captured as regressions
- live read-only check maps TheRock #7282 to covering PR #7357 using matching original llvm cherry-pick provenance

## Rollout

This PR is intentionally a draft. The included train remains in validate mode. Do not mark ready or enable write mode before operator and security review.