### PR TITLE
Add BKC release workflow inputs

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -5,18 +5,22 @@ name: Multi-Arch Release
 # Release type | Trigger details
 # ------------ | --------------------------------------------------------------
 # dev          | "workflow_dispatch" for testing with any set of inputs
+# dev-bkc      | "workflow_dispatch" for BKC development builds
 # nightly      | "schedule", or "workflow_dispatch" as needed (default inputs)
+# nightly-bkc  | "workflow_dispatch" for BKC nightly builds
 # prerelease   | "workflow_dispatch" for stable releases (explicit GPU family lists?)
 
 on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: choice
         options:
           - dev
+          - dev-bkc
           - nightly
+          - nightly-bkc
           - prerelease
         default: dev
       prerelease_version:

--- a/.github/workflows/multi_arch_release_asan.yml
+++ b/.github/workflows/multi_arch_release_asan.yml
@@ -5,18 +5,22 @@ name: Multi-Arch Release ASAN
 # Release type | Trigger details
 # ------------ | --------------------------------------------------------------
 # dev          | "workflow_dispatch" for testing with any set of inputs
+# dev-bkc      | "workflow_dispatch" for BKC development builds
 # nightly      | "schedule", or "workflow_dispatch" as needed (default inputs)
+# nightly-bkc  | "workflow_dispatch" for BKC nightly builds
 # prerelease   | "workflow_dispatch" for stable releases (explicit GPU family lists?)
 
 on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: choice
         options:
           - dev
+          - dev-bkc
           - nightly
+          - nightly-bkc
           - prerelease
         default: dev
       prerelease_version:

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -11,9 +11,15 @@ on:
         type: string
         default: ""
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
-        type: string
-        required: true
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
+        type: choice
+        options:
+          - dev
+          - dev-bkc
+          - nightly
+          - nightly-bkc
+          - prerelease
+        default: dev
       rocm_version:
         description: "ROCm package version to build against."
         type: string

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -18,11 +18,13 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease". Selects the S3 bucket.'
         type: choice
         options:
           - dev
+          - dev-bkc
           - nightly
+          - nightly-bkc
           - prerelease
         default: dev
       cache_type:

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -18,11 +18,13 @@ on:
         type: string
         required: true
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease". Selects the S3 bucket.'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease". Selects the S3 bucket.'
         type: choice
         options:
           - dev
+          - dev-bkc
           - nightly
+          - nightly-bkc
           - prerelease
         default: dev
       cache_type:

--- a/.github/workflows/multi_arch_repackage.yml
+++ b/.github/workflows/multi_arch_repackage.yml
@@ -12,11 +12,13 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type: "dev", "nightly", or "prerelease".'
+        description: 'Release type: "dev", "dev-bkc", "nightly", "nightly-bkc", or "prerelease".'
         type: choice
         options:
           - dev
+          - dev-bkc
           - nightly
+          - nightly-bkc
           - prerelease
         default: dev
       prerelease_version:

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -42,7 +42,7 @@ on:
       release_type:
         description: "Release type for the artifacts being tested; passed through to TheRock."
         type: string
-        default: dev
+        default: ""
       repository:
         description: "TheRock repository to checkout."
         type: string

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -40,9 +40,9 @@ on:
         type: string
         default: 'false'
       release_type:
-        description: 'Release type: "" for CI, or "dev", "nightly", "prerelease".'
+        description: "Release type for the artifacts being tested; passed through to TheRock."
         type: string
-        default: ""
+        default: dev
       repository:
         description: "TheRock repository to checkout."
         type: string

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -15,9 +15,9 @@ on:
         required: true
         type: string
       release_type:
-        description: "Release Type (ci, dev, nightly, prerelease)."
-        required: true
+        description: "Release type for the artifacts being tested; passed through to TheRock."
         type: string
+        default: dev
       gpg_key_url:
         description: "GPG key URL for signed repos"
         type: string

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -16,8 +16,8 @@ on:
         type: string
       release_type:
         description: "Release type for the artifacts being tested; passed through to TheRock."
+        required: true
         type: string
-        default: dev
       gpg_key_url:
         description: "GPG key URL for signed repos"
         type: string


### PR DESCRIPTION
## Motivation

* Progress on https://github.com/ROCm/rockrel/issues/88
* Companion PR to https://github.com/ROCm/TheRock/pull/7392

We're creating a new release stream that will branch off from nightly releases while carrying cherry-picks. This PR adds the new `dev-bkc` and `nightly-bkc` release type to the workflows so we can trigger with `workflow_dispatch`

## Technical Details

> [!IMPORTANT]
> This PR targets the `main` branch, and it will then be cherry-picked to the [`release/bkc/therock-10.1-20260811`](https://github.com/ROCm/rockrel/tree/release/bkc/therock-10.1-20260811) branch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
