### PR TITLE
feat(ci):Add `build_variant` input to `test_native_linux_packages_install.yml`

### DIFF
--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -46,6 +46,10 @@ on:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow"
         type: string
         default: ""
+      build_variant:
+        description: "Build variant (e.g. 'asan'). Changes expected package names to match variant-suffixed packages."
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -82,6 +86,7 @@ jobs:
       test_type: ${{ inputs.test_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      build_variant: ${{ inputs.build_variant }}
 
   notify_quartz_completed:
     name: "Quartz - completed - test rpm/deb install (rockrel)"


### PR DESCRIPTION
## Motivation
The release / Linux::release / Trigger Native Install Test - rhel8 job was failing because the release workflow dispatched
test_native_linux_packages_install.yml with a build_variant input that the workflow didn't declare. GitHub's API rejected the dispatch immediately with:
```
  Unexpected inputs provided: ["build_variant"]
```
This adds build_variant as an optional workflow_dispatch input and threads it through to the upstream ROCm/TheRock workflow call, so the caller's "release" value (and any future variant like "asan") is accepted and forwarded correctly.

Follows ROCm/TheRock@97676f4b949e62b5414444387ec971a35df397d4 which added build_variant support to the upstream workflow.

## Test Result

https://github.com/ROCm/rockrel/actions/runs/31998532467 -- install steps triggered successfully
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
