### PR TITLE
Cherry-pick: Adding build variant to native linux install workflow

### DIFF
--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -46,6 +46,10 @@ on:
         description: "Branch, tag or SHA to checkout. Defaults to the reference or SHA that triggered the workflow"
         type: string
         default: ""
+      build_variant:
+        description: "Build variant (e.g. 'asan'). Changes expected package names to match variant-suffixed packages."
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -67,3 +71,4 @@ jobs:
       test_type: ${{ inputs.test_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      build_variant: ${{ inputs.build_variant }}


### PR DESCRIPTION
Cherry-pick: Adding build variant to native linux install workflow

Cherry pick of this commits from rockrel main.

- [feat(ci):Add build_variant input to test_native_linux_packages_install.yml](https://github.com/ROCm/rockrel/pull/96/changes/314264e83506510332f98a49c9df441924a81d2c)
   
This change is needed for successful native linux install test workflow in the release/asan jobs.

Original PR: https://github.com/ROCm/rockrel/pull/96

ISSUE ID : https://github.com/ROCm/TheRock/issues/7342