### PR TITLE
[Quartz] Enable release-lineage tracking by default

### DIFF
--- a/.github/workflows/multi_arch_release.yml
+++ b/.github/workflows/multi_arch_release.yml
@@ -35,6 +35,13 @@ on:
         description: "TheRock branch, tag, or SHA. Empty = default branch."
         type: string
         default: ""
+      # Enable Quartz release-lineage tracking. When on, TheRock propagates this
+      # run's id to every triggered workflow as quartz_tracking_id, formatted as
+      # "<github.run_id>;<release_type>". Scheduled nightly runs always enable it.
+      enable_quartz_tracking:
+        description: "Enable Quartz release-lineage tracking (on by default)."
+        type: boolean
+        default: true
 
   # Trigger on a schedule to build nightly releases.
   schedule:
@@ -76,6 +83,7 @@ jobs:
       run_full_pytorch_tests: ${{ github.event_name == 'schedule' || inputs.release_type == 'prerelease' }}
       repository: "ROCm/TheRock"
       ref: ${{ inputs.ref || '' }}
+      enable_quartz_tracking: ${{ github.event_name == 'schedule' || inputs.enable_quartz_tracking }}
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/multi_arch_release_linux_jax_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_jax_wheels.yml
@@ -34,6 +34,12 @@ on:
         description: "Single Python version to build (empty for full matrix)"
         type: string
         default: ''
+      quartz_tracking_id:
+        description: >-
+          Leave empty. Internal Quartz tracking id, set automatically to link
+          this run to its release lineage.
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -68,6 +74,7 @@ jobs:
       repository: ${{ inputs.repository || 'ROCm/TheRock' }}
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:
     name: "Quartz - completed - release JAX wheels (rockrel)"

--- a/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_linux_pytorch_wheels.yml
@@ -49,6 +49,12 @@ on:
         description: "Build runner label"
         type: string
         default: "aws-linux-scale-rocm-prod"
+      quartz_tracking_id:
+        description: >-
+          Leave empty. Internal Quartz tracking id, set automatically to link
+          this run to its release lineage.
+        type: string
+        default: ""
 
 permissions:
   id-token: write
@@ -87,6 +93,7 @@ jobs:
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
       build_runs_on: ${{ inputs.build_runs_on }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:
     name: "Quartz - completed - release PyTorch wheels (rockrel)"

--- a/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
+++ b/.github/workflows/multi_arch_release_windows_pytorch_wheels.yml
@@ -45,6 +45,12 @@ on:
         description: "Build runner label"
         type: string
         default: "aws-windows-scale-rocm-prod"
+      quartz_tracking_id:
+        description: >-
+          Leave empty. Internal Quartz tracking id, set automatically to link
+          this run to its release lineage.
+        type: string
+        default: ""
 
 permissions:
   id-token: write
@@ -81,6 +87,7 @@ jobs:
       ref: ${{ inputs.ref || '' }}
       python_version: ${{ inputs.python_version }}
       build_runs_on: ${{ inputs.build_runs_on }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:
     name: "Quartz - completed - release PyTorch wheels (rockrel)"

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -55,6 +55,12 @@ on:
         description: "Build variant (e.g., release, asan)."
         type: string
         default: "release"
+      quartz_tracking_id:
+        description: >-
+          Leave empty. Internal Quartz tracking id, set automatically to link
+          this run to its release lineage.
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -96,6 +102,7 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       build_variant: ${{ inputs.build_variant }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:
     name: "Quartz - completed - test ROCm artifacts (rockrel)"

--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -50,6 +50,12 @@ on:
         description: "Build variant (e.g. 'asan'). Changes expected package names to match variant-suffixed packages."
         type: string
         default: ""
+      quartz_tracking_id:
+        description: >-
+          Leave empty. Internal Quartz tracking id, set automatically to link
+          this run to its release lineage.
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -87,6 +93,7 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       build_variant: ${{ inputs.build_variant }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:
     name: "Quartz - completed - test rpm/deb install (rockrel)"

--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -53,6 +53,12 @@ on:
         description: "Branch, tag, or SHA to checkout in TheRock."
         type: string
         default: ""
+      quartz_tracking_id:
+        description: >-
+          Leave empty. Internal Quartz tracking id, set automatically to link
+          this run to its release lineage.
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -91,6 +97,7 @@ jobs:
       tests_to_include: ${{ inputs.tests_to_include }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
+      quartz_tracking_id: ${{ inputs.quartz_tracking_id }}
 
   notify_quartz_completed:
     name: "Quartz - completed - test PyTorch wheels (full suite)"


### PR DESCRIPTION
## Summary

We add explicit `quartz_tracking_id` plumbing to rockrel's release
workflows so Quartz can reconstruct a release run's lineage from one
authoritative field. Today Quartz infers the top-level owner with a
fragile heuristic that probes unrelated inputs and the immediate GitHub
parent, and for async-dispatched workflows (which receive a brand-new
`run_id`) there is no signal at all. This change gives every reachable
workflow a self-describing field that carries the top-level run id.

This is the rockrel-side counterpart to ROCm/TheRock#7443, which does
the TheRock-side plumbing. rockrel is the production release
orchestrator, so tracking is enabled here by default.

## Changes

- **`multi_arch_release.yml`** (top-level): adds an
  `enable_quartz_tracking` boolean dispatch input, default `true`, and
  passes `github.event_name == 'schedule' || inputs.enable_quartz_tracking`
  to TheRock's `multi_arch_release@main`. The `schedule` term guarantees
  scheduled nightly runs enable tracking, even though schedule triggers
  carry no dispatch inputs. TheRock then computes the value as
  `"<github.run_id>;<release_type>"`.
- **Six benc-uk dispatch targets** (`test_artifacts.yml`,
  `test_native_linux_packages_install.yml`, `test_pytorch_wheels_full.yml`,
  `multi_arch_release_linux_pytorch_wheels.yml`,
  `multi_arch_release_linux_jax_wheels.yml`,
  `multi_arch_release_windows_pytorch_wheels.yml`): each declares a
  `quartz_tracking_id` string input (default `""`) and forwards it into
  its `uses: ROCm/TheRock/...@main` with: block.

## Why the wrappers must declare the input

TheRock's async `benc-uk/workflow-dispatch` edges carry no `repo:`, so
under a rockrel run they target rockrel's own wrapper copies. The
`workflow_dispatch` REST API rejects undefined inputs with HTTP 422, so
these wrappers must declare `quartz_tracking_id` or the nightly dispatch
would break once TheRock#7443 starts sending it.

## Merge order

Safe in either order. These wrappers accept the field whether or not it
is sent (default `""`), and TheRock only starts sending it after #7443
merges.

## Test plan

- [x] `actionlint` clean on all seven edited workflows.
- [ ] Manual `workflow_dispatch` of `multi_arch_release.yml` with the
      toggle on, confirming the id reaches Quartz (needs ROCm/TheRock#7443 merged first).
- [ ] Confirm a scheduled nightly run reports tracking enabled.