### PR TITLE
Add uninstall test option to native linux package install test

### DIFF
--- a/.github/workflows/test_native_linux_packages_install.yml
+++ b/.github/workflows/test_native_linux_packages_install.yml
@@ -50,6 +50,10 @@ on:
         description: "Build variant (e.g. 'asan'). Changes expected package names to match variant-suffixed packages."
         type: string
         default: ""
+      run_uninstall:
+        description: "Enable uninstall verification: remove installed ROCm metapackages and assert clean teardown (sanity/full only). Disabled by default."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -87,6 +91,7 @@ jobs:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       build_variant: ${{ inputs.build_variant }}
+      run_uninstall: ${{ inputs.run_uninstall }}
 
   notify_quartz_completed:
     name: "Quartz - completed - test rpm/deb install (rockrel)"


### PR DESCRIPTION
## Motivation

This pull request adds an optional uninstall and verification step to the native Linux package installation test workflow. After installing and verifying ROCm packages, the workflow can now optionally uninstall the packages and assert a clean system teardown. This is controlled by a new run_uninstall input/flag

Dependent Change: https://github.com/ROCm/TheRock/pull/7184

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
