### PR TITLE
Update `package_index_url`

### DIFF
--- a/.github/workflows/test_pytorch_wheels_full.yml
+++ b/.github/workflows/test_pytorch_wheels_full.yml
@@ -25,7 +25,7 @@ on:
       package_index_url:
         type: string
         required: true
-        default: "https://rocm.nightlies.amd.com/v4/whl-staging"
+        default: "https://nightly.repo.amd.com/rocm/whl-next/"
       python_version:
         type: string
         required: true


### PR DESCRIPTION
## Motivation

Updates the default `package_index_url` to point to the new nightly index.

Issue https://github.com/ROCm/TheRock/issues/6950

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
