### PR TITLE
fix(ci): remove `windows_hip_rocr_tests` input dropped by TheRock#7490

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -36,9 +36,6 @@ on:
       run_extended_tests:
         type: string
         default: 'false'
-      windows_hip_rocr_tests:
-        type: string
-        default: 'false'
       release_type:
         description: "Release type for the artifacts being tested; passed through to TheRock."
         type: string
@@ -97,7 +94,6 @@ jobs:
       test_type: ${{ inputs.test_type }}
       test_labels: ${{ inputs.test_labels }}
       run_extended_tests: ${{ inputs.run_extended_tests }}
-      windows_hip_rocr_tests: ${{ inputs.windows_hip_rocr_tests }}
       release_type: ${{ inputs.release_type }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Summary

  - Removes `windows_hip_rocr_tests` input declaration from `on.workflow_dispatch.inputs`
  - Removes `windows_hip_rocr_tests` forwarding from `jobs.test.with`

## Motivation

  ROCm/TheRock#7490 (`590646bbc9b8`, merged 2026-08-24) removed `windows_hip_rocr_tests` from the `workflow_call` interface of `test_artifacts.yml` — the flag is now handled internally by `fetch_test_configurations.py`. This wrapper was not updated in sync, causing every dispatched `Test Artifacts` run to fail with `startup_failure` before any job starts, because GitHub Actions rejects unknown inputs to reusable workflows.

Fixes: https://github.com/ROCm/rockrel/actions/runs/32806560050

## Root Cause

  TheRock commit that broke this: ROCm/TheRock@590646bbc9b8
  ```diff
  -      windows_hip_rocr_tests:
  -        type: string
  -        default: 'false'
  ```
```diff
-     windows_hip_rocr_tests: ${{ inputs.windows_hip_rocr_tests }}
```
  Removed from both workflow_dispatch.inputs and workflow_call.inputs in TheRock, but not from this wrapper.

## Test Plan

  - [x] Trigger a Test Artifacts workflow dispatch manually and confirm it reaches the configure_test_matrix job (no longer startup_failure) 
    - Test Run: https://github.com/ROCm/rockrel/actions/runs/32810344084


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
